### PR TITLE
Make it possible to omit the file system type for lmv::volume

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -40,6 +40,11 @@ be shortened to be:
 
     volume("myvg", "/dev/hdc", "mylv", "ext3", "20G")
 
+If you want to omit the file system type, but still specify the size of the
+logical volume, i.e. in the case if you are planning on using this logical
+volume as a swap partition or a block device for a virtual machine image, you
+need to use a hash to pass the parameters to the definition.
+
 If you need a more complex configuration, you'll need to build the
 resources out yourself.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,4 @@
-define lvm::volume($vg, $pv, $fstype, $size = undef, $ensure) {
+define lvm::volume($vg, $pv, $fstype = undef, $size = undef, $ensure) {
   case $ensure {
     #
     # Clean up the whole chain.
@@ -21,7 +21,11 @@ define lvm::volume($vg, $pv, $fstype, $size = undef, $ensure) {
       physical_volume { $pv: ensure => present }
       volume_group { $vg: ensure => present, physical_volumes => $pv, require => Physical_volume[$pv] }
       logical_volume { $name: ensure => present, volume_group => $vg, size => $size, require => Volume_group[$vg] }
-      filesystem { "/dev/${vg}/${name}": ensure => present, fs_type => $fstype, require => Logical_volume[$name] }
+
+      if $fstype != undef {
+          filesystem { "/dev/${vg}/${name}": ensure => present, fs_type => $fstype, require => Logical_volume[$name] }
+      }
+
     }
     default: {
      fail ( 'puppet-lvm::volume: ensure parameter can only be set to cleaned, absent or present' )


### PR DESCRIPTION
Even though one would probably want to omit the file system type more
often than the size, I didn't dare to change the order of the parameters
in order to preserve backwards compatibility
