### PR TITLE
Add option for initial_size

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,4 @@
-define lvm::volume($vg, $pv, $fstype = undef, $size = undef, $ensure) {
+define lvm::volume($vg, $pv, $fstype = undef, $size = undef, $initial_size = undef, $ensure) {
   case $ensure {
     #
     # Clean up the whole chain.
@@ -56,6 +56,7 @@ define lvm::volume($vg, $pv, $fstype = undef, $size = undef, $ensure) {
         ensure       => present,
         volume_group => $vg,
         size         => $size,
+        initial_size => $initial_size,
         require      => Volume_group[$vg]
       }
 


### PR DESCRIPTION
Added option for initial_size, enabling one to create a partition / resizing it later without puppet warning you about decreasing risks.

This is a very minor change, as the type already supported initial_size.
