### PR TITLE
Fix detection of physical volumes

### DIFF
--- a/lib/puppet/provider/volume_group/lvm.rb
+++ b/lib/puppet/provider/volume_group/lvm.rb
@@ -31,15 +31,17 @@ Puppet::Type.type(:volume_group).provide :lvm do
     end
 
     def physical_volumes
-        lines = pvs('-o', 'pv_name,vg_name', '--separator', ',')
-        lines.inject([]) do |memo, line|
-            pv, vg = line.split(',').map { |s| s.strip }
-            if vg == @resource[:name]
-                memo << pv
-            else
-                memo
-            end
+        volumes = []
+        lines = pvs('-o', 'pv_name,vg_name', '--separator', ',').split("\n")
+
+        lines.each do |line|
+          pv, vg = line.split(',').map(&:strip)
+          if vg == @resource[:name]
+            volumes << pv
+          end
         end
+
+        return volumes
     end
 
     private


### PR DESCRIPTION
The detection of physical volumes does not work at Debian Wheezy and Ubuntu Quantal (Ruby 1.9.3), because the result is a string instead of an array.

```
Debug: Executing '/sbin/pvs /dev/vda5'
Debug: Executing '/sbin/vgs vg0'
Debug: Executing '/sbin/pvs -o pv_name,vg_name --separator ,'
Error: /Stage[main]//Node[default]/Lvm::Volume[swap]/Volume_group[vg0]: Could not evaluate: undefined method `inject' for "  PV,VG\n  /dev/vda5,vg0\n":String
```
