### PR TITLE
Fix undefined method: inject for String

### DIFF
--- a/lib/puppet/provider/volume_group/lvm.rb
+++ b/lib/puppet/provider/volume_group/lvm.rb
@@ -32,14 +32,9 @@ Puppet::Type.type(:volume_group).provide :lvm do
 
     def physical_volumes
         lines = pvs('-o', 'pv_name,vg_name', '--separator', ',')
-        lines.inject([]) do |memo, line|
-            pv, vg = line.split(',').map { |s| s.strip }
-            if vg == @resource[:name]
-                memo << pv
-            else
-                memo
-            end
-        end
+        lines.split(/\n/).grep(/,#{@resource[:name]}$/).map { |s|
+            s.split(/,/)[0].strip
+        }
     end
 
     private


### PR DESCRIPTION
The physical_volumes extraction using inject function doesn't work.
Change to using split/grep/map.

/Stage[main]/Releng::Disks/Volume_group[vg](err): Could not evaluate: undefined method `inject' for "  PV,VG\n/dev/sda4,vg\n":String

Signed-off-by: Robin H. Johnson robbat2@gentoo.org
