### PR TITLE
Maint/simplify require spec helper

### DIFF
--- a/spec/unit/puppet/provider/filesystem/lvm_spec.rb
+++ b/spec/unit/puppet/provider/filesystem/lvm_spec.rb
@@ -1,4 +1,4 @@
-Dir.chdir(File.dirname(__FILE__)) { (s = lambda { |f| File.exist?(f) ? require(f) : Dir.chdir("..") { s.call(f) } }).call("spec/spec_helper.rb") }
+require 'spec_helper'
 
 provider_class = Puppet::Type.type(:filesystem).provider(:lvm)
 

--- a/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
+++ b/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
@@ -1,4 +1,4 @@
-Dir.chdir(File.dirname(__FILE__)) { (s = lambda { |f| File.exist?(f) ? require(f) : Dir.chdir("..") { s.call(f) } }).call("spec/spec_helper.rb") }
+require 'spec_helper'
 
 provider_class = Puppet::Type.type(:logical_volume).provider(:lvm)
 

--- a/spec/unit/puppet/provider/physical_volume/lvm_spec.rb
+++ b/spec/unit/puppet/provider/physical_volume/lvm_spec.rb
@@ -1,4 +1,4 @@
-Dir.chdir(File.dirname(__FILE__)) { (s = lambda { |f| File.exist?(f) ? require(f) : Dir.chdir("..") { s.call(f) } }).call("spec/spec_helper.rb") }
+require 'spec_helper'
 
 provider_class = Puppet::Type.type(:physical_volume).provider(:lvm)
 

--- a/spec/unit/puppet/provider/volume_group/lvm_spec.rb
+++ b/spec/unit/puppet/provider/volume_group/lvm_spec.rb
@@ -1,4 +1,4 @@
-Dir.chdir(File.dirname(__FILE__)) { (s = lambda { |f| File.exist?(f) ? require(f) : Dir.chdir("..") { s.call(f) } }).call("spec/spec_helper.rb") }
+require 'spec_helper'
 
 provider_class = Puppet::Type.type(:volume_group).provider(:lvm)
 

--- a/spec/unit/puppet/type/filesystem_spec.rb
+++ b/spec/unit/puppet/type/filesystem_spec.rb
@@ -1,4 +1,4 @@
-Dir.chdir(File.dirname(__FILE__)) { (s = lambda { |f| File.exist?(f) ? require(f) : Dir.chdir("..") { s.call(f) } }).call("spec/spec_helper.rb") }
+require 'spec_helper'
 
 describe Puppet::Type.type(:filesystem) do
     before do

--- a/spec/unit/puppet/type/logical_volume_spec.rb
+++ b/spec/unit/puppet/type/logical_volume_spec.rb
@@ -1,4 +1,4 @@
-Dir.chdir(File.dirname(__FILE__)) { (s = lambda { |f| File.exist?(f) ? require(f) : Dir.chdir("..") { s.call(f) } }).call("spec/spec_helper.rb") }
+require 'spec_helper'
 
 describe Puppet::Type.type(:logical_volume) do
     before do

--- a/spec/unit/puppet/type/physical_volume_spec.rb
+++ b/spec/unit/puppet/type/physical_volume_spec.rb
@@ -1,4 +1,4 @@
-Dir.chdir(File.dirname(__FILE__)) { (s = lambda { |f| File.exist?(f) ? require(f) : Dir.chdir("..") { s.call(f) } }).call("spec/spec_helper.rb") }
+require 'spec_helper'
 
 describe Puppet::Type.type(:physical_volume) do
     before do

--- a/spec/unit/puppet/type/volume_group_spec.rb
+++ b/spec/unit/puppet/type/volume_group_spec.rb
@@ -1,4 +1,4 @@
-Dir.chdir(File.dirname(__FILE__)) { (s = lambda { |f| File.exist?(f) ? require(f) : Dir.chdir("..") { s.call(f) } }).call("spec/spec_helper.rb") }
+require 'spec_helper'
 
 describe Puppet::Type.type(:volume_group) do
     before do


### PR DESCRIPTION
With rspec 2 simply doing `require 'spec_helper'` will bring in the
project spec helper. This commit removes the existing complex require
logic with a simple require statement.

This pull request depends on pull request 21
(https://github.com/puppetlabs/puppetlabs-lvm/pull/21)
