### PR TITLE
use 'blkid' instead of 'mount' to check the filesystem type

### DIFF
--- a/lib/puppet/provider/filesystem/lvm.rb
+++ b/lib/puppet/provider/filesystem/lvm.rb
@@ -1,7 +1,7 @@
 Puppet::Type.type(:filesystem).provide :lvm do
     desc "Manages filesystem of a logical volume"
 
-    commands :mount => 'mount'
+    commands :blkid => 'blkid'
 
     def create
         mkfs(@resource[:fs_type])
@@ -16,7 +16,7 @@ Puppet::Type.type(:filesystem).provide :lvm do
     end
 
     def fstype
-        mount('-f', '--guess-fstype', @resource[:name]).strip
+        /TYPE=\"(\S+)\"/.match(blkid(@resource[:name]))[1]
     rescue Puppet::ExecutionFailure
         nil
     end

--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
              :lvs       => 'lvs',
              :resize2fs => 'resize2fs',
              :umount    => 'umount',
-             :mount     => 'mount',
+             :blkid     => 'blkid',
              :dmsetup   => 'dmsetup'
 
     def create
@@ -91,7 +91,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
 
             lvextend( '-L', new_size, path) || fail( "Cannot extend to size #{size} because lvextend failed." )
 
-            if mount( '-f', '--guess-fstype', path) =~ /ext[34]/
+            if /TYPE=\"(\S+)\"/.match(blkid(path)) {|m| m =~ /ext[34]/}
               resize2fs( path) || fail( "Cannot resize file system to size #{size} because resize2fs failed." )
             end
 

--- a/spec/unit/puppet/provider/logical_volume/lvm.rb
+++ b/spec/unit/puppet/provider/logical_volume/lvm.rb
@@ -42,7 +42,7 @@ describe provider_class do
                     @provider.expects(:lvs).with('--noheading', '--unit', 'g', '/dev/myvg/mylv').returns(' 1.00g').at_least_once
                     @provider.expects(:lvs).with('--noheading', '-o', 'vg_extent_size', '--units', 'k', '/dev/myvg/mylv').returns(' 1000.00k')
                     @provider.expects(:lvextend).with('-L', '2000000k', '/dev/myvg/mylv').returns(true)
-                    @provider.expects(:mount).with('-f', '--guess-fstype', '/dev/myvg/mylv')
+                    @provider.expects(:blkid).with('/dev/myvg/mylv')
                     @provider.size = '2000000k'
                 end
             end


### PR DESCRIPTION
The options "--guess-fstype" was removed from the mount command [1].
Commands "fsck -N" and "file -sL" were also tested but their output are
not consitent between filesystems. 'blkid' seems to be the best candidate
to replace 'mount' and this utility is also present in the standard
package util-linux.

This patch fix the following bug https://projects.puppetlabs.com/issues/19410

[1] http://git.kernel.org/?p=utils/util-linux/util-linux.git;a=commit;h=0377ef91270d06592a0d4dd009c29e7b1ff9c9b8
