### PR TITLE
Bug/21826: resize2fs isn't called during resizing on ruby>1.8

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -99,7 +99,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
 
             lvextend( '-L', new_size, path) || fail( "Cannot extend to size #{new_size} because lvextend failed." )
 
-            if /TYPE=\"(\S+)\"/.match(blkid(path)) {|m| m =~ /ext[34]/}
+            if blkid(path) =~ /\bTYPE=\"(ext[34])\"/
               resize2fs( path) || fail( "Cannot resize file system to size #{new_size} because resize2fs failed." )
             end
 


### PR DESCRIPTION
http://projects.puppetlabs.com/issues/21826

Thanks to @nilium for help with gist and ruby testing.

(testing editing the comment to make travis see this)
