### PR TITLE
Travis check for syntax and lint before spec tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,3 @@
+fixtures:
+  symlinks:
+    "lvm": "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
     - master
 language: ruby
 bundler_args: --without development
-script: bundle exec rake spec SPEC_OPTS='--format documentation'
+script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'
 after_success:
   - git clone -q git://github.com/puppetlabs/ghpublisher.git .forge-releng
   - .forge-releng/publish

--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,5 @@ else
   gem 'puppet', :require => false
 end
 
+gem 'puppet-lint', '>= 0.3.2'
 # vim:ft=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,12 @@
 require 'rubygems'
 require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+
+desc "Run puppet in noop mode and check for syntax errors."
+task :validate do
+   Dir['manifests/**/*.pp'].each do |path|
+     sh "puppet parser validate --noop #{path}"
+   end
+end


### PR DESCRIPTION
Without this patch lint and syntax checks were not being done before the
rspec tests. This ensures that the code can be parsed and passes lint
before the spec tests.
