### PR TITLE
Make the XFS support optional, not required.

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -6,10 +6,11 @@ Puppet::Type.type(:logical_volume).provide :lvm do
              :lvextend   => 'lvextend',
              :lvs        => 'lvs',
              :resize2fs  => 'resize2fs',
-             :xfs_growfs => 'xfs_growfs',
              :umount     => 'umount',
              :blkid      => 'blkid',
              :dmsetup    => 'dmsetup'
+
+    optional_commands :xfs_growfs => 'xfs_growfs'
 
     def create
         args = ['-n', @resource[:name]]


### PR DESCRIPTION
With the xfs_growfs command required, the provider was failing
suitability tests and unavailable if the xfs_growfs command was not
installed:

debug: Puppet::Type::Logical_volume::ProviderLvm: file xfs_growfs does
not exist
err: Could not find a suitable provider for logical_volume
