### PR TITLE
Suppress facter warnings on systems that don't support LVM.

### DIFF
--- a/lib/facter/lvm_support.rb
+++ b/lib/facter/lvm_support.rb
@@ -4,7 +4,7 @@ Facter.add('lvm_support') do
   confine :kernel => :linux
 
   setcode do
-    vgdisplay =  Facter::Util::Resolution.exec('which vgs')
+    vgdisplay = Facter::Util::Resolution.which('vgs')
     vgdisplay.nil? ? nil : true
   end
 end

--- a/spec/unit/facter/lvm_support_spec.rb
+++ b/spec/unit/facter/lvm_support_spec.rb
@@ -23,7 +23,7 @@ describe 'lvm_support fact' do
     context 'when vgs is absent' do
       it 'should be set to no' do
         Facter::Util::Resolution.stubs('exec') # All other calls
-        Facter::Util::Resolution.expects('exec').with('which vgs').returns(nil)
+        Facter::Util::Resolution.expects('which').with('vgs').returns(nil)
         Facter.value(:lvm_support).should be_nil
       end
     end
@@ -31,7 +31,7 @@ describe 'lvm_support fact' do
     context 'when vgs is present' do
       it 'should be set to yes' do
         Facter::Util::Resolution.stubs('exec') # All other calls
-        Facter::Util::Resolution.expects('exec').with('which vgs').returns('/sbin/vgs')
+        Facter::Util::Resolution.expects('which').with('vgs').returns('/sbin/vgs')
         Facter.value(:lvm_support).should be_true
       end
     end


### PR DESCRIPTION
We were seeing these facter warnings when running puppet on our systems that don't use LVM:

/usr/bin/which: no vgs in (/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin)
