### PR TITLE
Fix issue 16174 (http://projects.puppetlabs.com/issues/16174) resize ext4 on rhel5 famliy systems

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -6,6 +6,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
              :lvextend   => 'lvextend',
              :lvs        => 'lvs',
              :resize2fs  => 'resize2fs',
+             :resize4fs  => 'resize4fs',
              :umount     => 'umount',
              :blkid      => 'blkid',
              :dmsetup    => 'dmsetup'
@@ -102,7 +103,9 @@ Puppet::Type.type(:logical_volume).provide :lvm do
             lvextend( '-L', new_size, path) || fail( "Cannot extend to size #{new_size} because lvextend failed." )
 
             blkid_type = blkid(path)
-            if blkid_type =~ /\bTYPE=\"(ext[34])\"/
+            if Facter.value(:osfamily) == 'RedHat' and Facter.value(:operatingsystemrelease) =~ /5\./ and blkid_type =~ /\bTYPE=\"(ext4)\"/
+              resize4fs( path) || fail( "Cannot resize file system to size #{new_size} because resize2fs failed." )
+            elsif blkid_type =~ /\bTYPE=\"(ext[34])\"/
               resize2fs( path) || fail( "Cannot resize file system to size #{new_size} because resize2fs failed." )
             elsif blkid_type =~ /\bTYPE=\"(xfs)\"/
               xfs_growfs( path) || fail( "Cannot resize filesystem to size #{new_size} because xfs_growfs failed." )


### PR DESCRIPTION
On RHEL 5 family systems ext4 filesystems can not be resized using resize2fs.
resize4fs from e4fsprogs (rpm -ql e2fsprogs|grep resize) is required.
This update checks that the system is rhel5 with a blockid of ext4 and calls resize4fs instead.
