### PR TITLE
Fix issue 16174 (http://projects.puppetlabs.com/issues/16174) resize ext4 on rhel5 famliy systems

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -103,7 +103,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
             lvextend( '-L', new_size, path) || fail( "Cannot extend to size #{new_size} because lvextend failed." )
 
             blkid_type = blkid(path)
-            if resize4fs.exists? and blkid_type =~ /\bTYPE=\"(ext4)\"/
+            if command(:resize4fs) and blkid_type =~ /\bTYPE=\"(ext4)\"/
               resize4fs( path) || fail( "Cannot resize file system to size #{new_size} because resize2fs failed." )
             elsif blkid_type =~ /\bTYPE=\"(ext[34])\"/
               resize2fs( path) || fail( "Cannot resize file system to size #{new_size} because resize2fs failed." )


### PR DESCRIPTION
On RHEL 5 family systems ext4 filesystems can not be resized using resize2fs.
resize4fs from e4fsprogs is required.
This update checks that the system is rhel5 with a blockid of ext4 and calls resize4fs instead.
