### PR TITLE
Fix error with not qualified command

### DIFF
--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -44,7 +44,7 @@ define lvm::logical_volume(
   exec { "ensure mountpoint '${mountpath}' exists":
     command => "mkdir -p ${mountpath}",
     unless  => "test -d ${mountpath}",
-    path    => "/bin/:/usr/bin/",
+    path    => "/usr/bin/:/bin/",
   } ->
   mount {$mountpath:
     ensure  => $mount_ensure,


### PR DESCRIPTION
On Debian 6 i have an error:

Error: Failed to apply catalog: Parameter unless failed on Exec[ensure mountpoint 'dir' exists]: 'test -d dir' is not qualified and no path was specified. Please qualify the command or specify a path. at /etc/puppet/modules/lvm/manifests/logical_volume.pp:47
Wrapped exception:
'test -d dir' is not qualified and no path was specified. Please qualify the command or specify a path.

because 'test' in debian located in /usr/bin/ directory
