### PR TITLE
Add swap partition support

### DIFF
--- a/lib/puppet/provider/filesystem/lvm.rb
+++ b/lib/puppet/provider/filesystem/lvm.rb
@@ -23,7 +23,11 @@ Puppet::Type.type(:filesystem).provide :lvm do
 
     def mkfs(fs_type)
         mkfs_params = { "reiserfs" => "-q" }
-        mkfs_cmd    = ["mkfs.#{fs_type}", @resource[:name]]
+        if fs_type == "swap"
+            mkfs_cmd    = ["mkswap", @resource[:name]]
+        else
+            mkfs_cmd    = ["mkfs.#{fs_type}", @resource[:name]]
+        end
         
         if mkfs_params[fs_type]
             mkfs_cmd << mkfs_params[fs_type]


### PR DESCRIPTION
It seems like the swap partitions were not supported. So I have tried to add the swap partition support using just the logical_volume.pp and the filesystem provider.

filesystem provider needed to be updated, because it actually creates the filesystem, so in case of swap we need to use mkswap utility instead of mkfs.*

In logical_volume.pp I have made sure that /etc/fstab has the workable and correct entry, plus the swap is added to system swap using swapon -a. The only issue here is in /etc/fstab that the mount point for swap should be none.