### PR TITLE
Fix a size comparison

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -91,7 +91,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
         if lvm_size_units[current_size_unit] < lvm_size_units[new_size_unit]
             resizeable = true
         elsif lvm_size_units[current_size_unit] > lvm_size_units[new_size_unit]
-            if (current_size_bytes / lvm_size_units[current_size_unit]) < (new_size_bytes / lvm_size_units[new_size_unit])
+            if (current_size_bytes * lvm_size_units[current_size_unit]) < (new_size_bytes * lvm_size_units[new_size_unit])
                 resizeable = true
             end
         elsif lvm_size_units[current_size_unit] == lvm_size_units[new_size_unit]


### PR DESCRIPTION
To correctly compare two sizes, each specified using a number with a letter suffix (M, G, &c), you have to multiply each number by the factor implied by the suffix, not divide it.  The current code would accept a change from e.g. 1G to 1M as an increase.
