### PR TITLE
Fix exec that was missing a path attribute

### DIFF
--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -42,6 +42,7 @@ define lvm::logical_volume(
   }
 
   exec { "ensure mountpoint '${mountpath}' exists":
+    path    => [ '/bin', '/usr/bin' ],
     command => "mkdir -p ${mountpath}",
     unless  => "test -d ${mountpath}",
   } ->


### PR DESCRIPTION
The exec will fail because the paths are not fully qualified.  The fix is to either declare a global path parameter to exec, or the patch below.
