### PR TITLE
Fix missing dependency that could result in lvs being created before vgs

### DIFF
--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -34,6 +34,7 @@ define lvm::logical_volume(
     ensure       => $ensure,
     volume_group => $volume_group,
     size         => $size,
+    require      => Volume_group[$volume_group],
   }
 
   filesystem {"/dev/${volume_group}/${name}":

--- a/manifests/volume_group.pp
+++ b/manifests/volume_group.pp
@@ -20,6 +20,7 @@ define lvm::volume_group(
     {
       ensure       => $ensure,
       volume_group => $name,
+      require      => Volume_group[$name],
     }
   )
 }


### PR DESCRIPTION
This will make sure that the logical volumes are only created after the volume groups are in place.  Without the require, sometimes the initial puppet run would fail.
