### PR TITLE
Add autorequire for the volume_group

### DIFF
--- a/lib/puppet/type/logical_volume.rb
+++ b/lib/puppet/type/logical_volume.rb
@@ -75,4 +75,8 @@ Puppet::Type.newtype(:logical_volume) do
             end
         end
     end
+
+    autorequire(:volume_group) do
+      @parameters[:volume_group].value
+    end
 end


### PR DESCRIPTION
This will make it so that logical volumes automatically require the volume_group that they are contained in.
