### PR TITLE
Resolve ambiguous reference warnings in Geppetto.

### DIFF
--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -30,13 +30,13 @@ define lvm::logical_volume(
     Logical_volume[$name]
   }
 
-  logical_volume { $name:
+  ::logical_volume { $name:
     ensure       => $ensure,
     volume_group => $volume_group,
     size         => $size,
   }
 
-  filesystem {"/dev/${volume_group}/${name}":
+  ::filesystem {"/dev/${volume_group}/${name}":
     ensure  => $ensure,
     fs_type => $fs_type,
   }

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -68,17 +68,17 @@ define lvm::volume (
     cleaned: {
       # This may only need to exist once
       if ! defined(Physical_volume[$pv]) {
-        physical_volume { $pv: ensure => present }
+        ::physical_volume { $pv: ensure => present }
       }
       # This may only need to exist once
       if ! defined(Volume_group[$vg]) {
-        volume_group { $vg:
+        ::volume_group { $vg:
           ensure           => present,
           physical_volumes => $pv,
           before           => Physical_volume[$pv]
         }
 
-        logical_volume { $name:
+        ::logical_volume { $name:
           ensure       => present,
           volume_group => $vg,
           size         => $size,
@@ -91,7 +91,7 @@ define lvm::volume (
     # Just clean up the logical volume
     #
     absent: {
-      logical_volume { $name:
+      ::logical_volume { $name:
         ensure       => absent,
         volume_group => $vg,
         size         => $size
@@ -107,14 +107,14 @@ define lvm::volume (
 
       # This may only need to exist once
       if ! defined(Volume_group[$vg]) {
-        volume_group { $vg:
+        ::volume_group { $vg:
           ensure           => present,
           physical_volumes => $pv,
           require          => Physical_volume[$pv]
         }
       }
 
-      logical_volume { $name:
+      ::logical_volume { $name:
         ensure       => present,
         volume_group => $vg,
         size         => $size,
@@ -123,7 +123,7 @@ define lvm::volume (
       }
 
       if $fstype != undef {
-        filesystem { "/dev/${vg}/${name}":
+        ::filesystem { "/dev/${vg}/${name}":
           ensure  => present,
           fs_type => $fstype,
           require => Logical_volume[$name]

--- a/manifests/volume_group.pp
+++ b/manifests/volume_group.pp
@@ -5,11 +5,11 @@ define lvm::volume_group(
 ) {
   validate_hash($logical_volumes)
 
-  physical_volume { $physical_volumes:
+  ::physical_volume { $physical_volumes:
     ensure => $ensure,
   }
 
-  volume_group { $name:
+  ::volume_group { $name:
     ensure           => $ensure,
     physical_volumes => $physical_volumes,
   }


### PR DESCRIPTION
The lvm module contains custom providers and definitions with identical
names that caused "Ambiguous reference" warnings in Eclipse Geppetto.