### PR TITLE
volume_group: physical_volumes is an unsorted array

### DIFF
--- a/lib/puppet/type/volume_group.rb
+++ b/lib/puppet/type/volume_group.rb
@@ -10,6 +10,10 @@ Puppet::Type.newtype(:volume_group) do
         desc "The list of physical volumes to be included in the volume group; this
              will automatically set these as dependencies, but they must be defined elsewhere
              using the physical_volume resource type."
+
+        def insync?(is)
+          should.sort == is.sort
+        end
     end
 
     newparam(:createonly, :boolean => true) do


### PR DESCRIPTION
The `physical_volumes` parameter of  `volume_group` resources should be treated as an unsorted array. Resources currently will have changes at every run if the array is not sorted the same way in `is` and `should`. This fixes it.
