### PR TITLE
Update lvm.rb to consider fs_type in exists? function

### DIFF
--- a/lib/puppet/provider/filesystem/lvm.rb
+++ b/lib/puppet/provider/filesystem/lvm.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:filesystem).provide :lvm do
     end
 
     def exists?
-        fstype != nil
+        fstype == @resource[:fs_type]
     end
 
     def destroy


### PR DESCRIPTION
The former check only checked, if any filesystem exists on the partition, not if the filesystem is the desired filesystem. In some cases this resulted in a wrong filesystem left on the partition.
