### PR TITLE
escape dashes in lv name for dmsetup remove

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -41,7 +41,8 @@ Puppet::Type.type(:logical_volume).provide :lvm do
     end
 
     def destroy
-        dmsetup('remove', "#{@resource[:volume_group]}-#{@resource[:name]}")
+        name_escaped = @resource[:name].gsub('-','--')
+        dmsetup('remove', "#{@resource[:volume_group]}-#{name_escaped}")
         lvremove('-f', path)
     end
 


### PR DESCRIPTION
We use dashes in our LV names and they are automatically escaped by LVM (The dashes are doubled). When we create VG myvg and LV my-lv, the lvcreate device is /dev/mapper/myvg-my--lv.

This only affects dmsetup remove. The other LVM commands and outputs use the unescaped names.
I'm not sure if a new set of tests should be created or if the current create and destroy test should be modified to use myvg/my-lv so I didn't make any spec changes.  