### PR TITLE
size_is_minsize enhancements

### DIFF
--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -17,6 +17,7 @@ define lvm::logical_volume (
   $stripesize        = undef,
   $readahead         = undef,
   $range             = undef,
+  $size_is_minsize   = undef,
 ) {
 
   validate_bool($mountpath_require)
@@ -43,15 +44,16 @@ define lvm::logical_volume (
   }
 
   logical_volume { $name:
-    ensure       => $ensure,
-    volume_group => $volume_group,
-    size         => $size,
-    initial_size => $initial_size,
-    stripes      => $stripes,
-    stripesize   => $stripesize,
-    readahead    => $readahead,
-    extents      => $extents,
-    range        => $range,
+    ensure          => $ensure,
+    volume_group    => $volume_group,
+    size            => $size,
+    initial_size    => $initial_size,
+    stripes         => $stripes,
+    stripesize      => $stripesize,
+    readahead       => $readahead,
+    extents         => $extents,
+    range           => $range,
+    size_is_minsize => $size_is_minsize,
   }
 
   filesystem { "/dev/${volume_group}/${name}":

--- a/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
+++ b/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
@@ -150,7 +150,7 @@ describe provider_class do
       end
     end
     context "with a smaller size" do
-      context "without size_is_minsize set to false" do
+      context "without size_is_minsize set to true" do
         it "should raise an exception" do
           @resource.expects(:[]).with(:name).returns('mylv').at_least_once
           @resource.expects(:[]).with(:volume_group).returns('myvg').at_least_once
@@ -166,7 +166,7 @@ describe provider_class do
           @provider.create
           @provider.expects(:lvs).with('--noheading', '--unit', 'g', '/dev/myvg/mylv').returns(' 1.00g').at_least_once
           @provider.expects(:lvs).with('--noheading', '-o', 'vg_extent_size', '--units', 'k', '/dev/myvg/mylv').returns(' 1000.00k')
-          proc { @provider.size = '1m' }.should raise_error(Puppet::Error, /manual/)
+          proc { @provider.size = '1m', @provider.allow_minsize = false }.should raise_error(Puppet::Error, /manual/)
         end
       end
       context "with size_is_minsize set to true" do
@@ -187,7 +187,7 @@ describe provider_class do
           @provider.create
           @provider.expects(:lvs).with('--noheading', '--unit', 'g', '/dev/myvg/mylv').returns(' 1.00g').at_least_once
           @provider.expects(:lvs).with('--noheading', '-o', 'vg_extent_size', '--units', 'k', '/dev/myvg/mylv').returns(' 1000.00k')
-          proc { @provider.size = '1m' }.should output(/already/).to_stdout
+          proc { @provider.size = '1m', @provider.allow_minsize = true }.should output(/already/).to_stdout
         end
       end
     end


### PR DESCRIPTION
These changes expose the size_is_minsize parameter in lvm::logical_volume and then actually make it usable by not triggering a resource change on each run.

In the current code with size_is_minsize==true, each run will show changed resources for each filesystem that is larger than the configured size:
Notice: Compiled catalog for et-wks01.et.udev in environment production in 0.11 seconds
Info: Applying configuration version '1419367202'
Info: Logical_volume[test](provider=lvm): Logical volume already has minimum size of 3G (currently 4G)
Notice: /Stage[main]/Main/Lvm::Logical_volume[test]/Logical_volume[test]/size: size changed '4G' to '3G'
Notice: /Stage[main]/Main/Lvm::Logical_volume[test]/Mount[/test]/ensure: ensure changed 'unmounted' to 'mounted'
Info: /Stage[main]/Main/Lvm::Logical_volume[test]/Mount[/test]: Scheduling refresh of Mount[/test]
Info: Mount[/test](provider=parsed): Remounting
Notice: /Stage[main]/Main/Lvm::Logical_volume[test]/Mount[/test]: Triggered 'refresh' from 1 events
Info: /Stage[main]/Main/Lvm::Logical_volume[test]/Mount[/test]: Scheduling refresh of Mount[/test]
Notice: Finished catalog run in 0.66 seconds

This resolves that by moving some of that logic into the size() function, and then if necessary, lying about the current size so the change isn't triggered.  Note the lack of the "Notice" resource with these patches applied and size_is_minsize==true:
Notice: Compiled catalog for et-wks01.et.udev in environment production in 0.13 seconds
Info: Applying configuration version '1419367342'
Info: Logical_volume[test](provider=lvm): Logical volume already has a minimum size of 3G (currently 4G)
Notice: /Stage[main]/Main/Lvm::Logical_volume[test]/Mount[/test]/ensure: ensure changed 'unmounted' to 'mounted'
Info: /Stage[main]/Main/Lvm::Logical_volume[test]/Mount[/test]: Scheduling refresh of Mount[/test]
Info: Mount[/test](provider=parsed): Remounting
Notice: /Stage[main]/Main/Lvm::Logical_volume[test]/Mount[/test]: Triggered 'refresh' from 1 events
Info: /Stage[main]/Main/Lvm::Logical_volume[test]/Mount[/test]: Scheduling refresh of Mount[/test]
Notice: Finished catalog run in 0.67 seconds