### PR TITLE
Fix filesystem type detection

### DIFF
--- a/lib/puppet/provider/filesystem/lvm.rb
+++ b/lib/puppet/provider/filesystem/lvm.rb
@@ -16,7 +16,7 @@ Puppet::Type.type(:filesystem).provide :lvm do
     end
 
     def fstype
-        /TYPE=\"(\S+)\"/.match(blkid(@resource[:name]))[1]
+        /\bTYPE=\"(\S+)\"/.match(blkid(@resource[:name]))[1]
     rescue Puppet::ExecutionFailure
         nil
     end


### PR DESCRIPTION
Sometimes `blkid` shows a `SEC_TYPE="ext2"` in addition to `TYPE="ext3"`.
It has something to do with a filesystem being backwards compatible with
ext2. This commit fixes the regex that matches TYPE=.. to prevent it
from matching SEC_TYPE.

Unfortunately I couldn't figure out how to add a test case for this. Any advice welcome if you think a test is necessary, thanks!