### PR TITLE
Allow different values for pass and dump

### DIFF
--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -6,6 +6,8 @@ define lvm::logical_volume (
   $initial_size      = undef,
   $ensure            = present,
   $options           = 'defaults',
+  $pass              = '2',
+  $dump              = '1',
   $fs_type           = 'ext4',
   $mkfs_options      = undef,
   $mountpath         = "/${name}",
@@ -66,8 +68,8 @@ define lvm::logical_volume (
     device  => "/dev/${volume_group}/${name}",
     fstype  => $fs_type,
     options => $options,
-    pass    => 2,
-    dump    => 1,
+    pass    => $pass,
+    dump    => $dump,
     atboot  => true,
   }
 }


### PR DESCRIPTION
Allow root filesystems to have pass specified as 1 instead of 2; allow the default dump value to be overridden if desired.