### PR TITLE
Made logical_volume $size an optional parameter

### DIFF
--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -2,7 +2,7 @@
 #
 define lvm::logical_volume (
   $volume_group,
-  $size,
+  $size              = undef,
   $initial_size      = undef,
   $ensure            = present,
   $options           = 'defaults',


### PR DESCRIPTION
Not setting it should use the entire physical drive.