### PR TITLE
mirrors - rc 3

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -8,7 +8,9 @@ Puppet::Type.type(:logical_volume).provide :lvm do
              :resize2fs  => 'resize2fs',
              :umount     => 'umount',
              :blkid      => 'blkid',
-             :dmsetup    => 'dmsetup'
+             :dmsetup    => 'dmsetup',
+             :lvconvert  => 'lvconvert',
+             :lvdisplay  => 'lvdisplay'
 
     optional_commands :xfs_growfs => 'xfs_growfs',
                       :resize4fs  => 'resize4fs'
@@ -35,6 +37,25 @@ Puppet::Type.type(:logical_volume).provide :lvm do
         if @resource[:stripesize]
             args.push('--stripesize', @resource[:stripesize])
         end
+
+
+        if @resource[:mirror]
+            args.push('--mirrors', @resource[:mirror])
+            if @resource[:mirrorlog]
+                args.push('--mirrorlog', @resource[:mirrorlog])
+            end
+            if @resource[:region_size]
+                args.push('--regionsize', @resource[:region_size])
+            end
+            if @resource[:no_sync]
+                args.push('--nosync')
+            end
+        end
+
+        if @resource[:alloc]
+            args.push('--alloc', @resource[:alloc])
+        end
+
 
         if @resource[:readahead]
             args.push('--readahead', @resource[:readahead])
@@ -131,6 +152,79 @@ Puppet::Type.type(:logical_volume).provide :lvm do
         end
     end
 
+
+    # Look up the current number of mirrors (0=no mirroring, 1=1 spare, 2=2 spares....). Return the number as string.
+    def mirror
+        raw = lvdisplay( path )
+        # If the first attribute bit is "m" or "M" then the LV is mirrored.
+        if raw =~ /Mirrored volumes\s+(\d+)/im
+            # Minus one because it says "2" when there is only one spare. And so on.
+            n = ($1.to_i)-1
+            #puts " current mirrors: #{n}"
+            return n.to_s 
+        end
+        return 0.to_s
+    end
+
+    def mirror=( new_mirror_count )
+        current_mirrors = mirror().to_i
+        if new_mirror_count.to_i != current_mirrors
+            puts "Change mirror from #{current_mirrors} to #{new_mirror_count}..."
+            args = ['-m', new_mirror_count]
+            if @resource[:mirrorlog]
+                args.push( '--mirrorlog', @resource[:mirrorlog] )
+            end
+
+            # Region size cannot be changed on an existing mirror (not even when changing to zero mirrors).
+            
+            if @resource[:alloc]
+                args.push( '--alloc', @resource[:alloc] )
+            end
+            args.push( path )
+            lvconvert( *args )
+        end
+    end
+
+    # Location of the mirror log. Empty string if mirror==0, else "mirrored", "disk" or "core".
+    def mirrorlog
+        vgname = "#{@resource[:volume_group]}"
+        lvname = "#{@resource[:name]}"
+        raw = lvs('-a', '-o', '+devices', vgpath)
+
+        if mirror().to_i > 0
+            if raw =~ /\[#{lvname}_mlog\]\s+#{vgname}\s+/im
+                if raw =~ /\[#{lvname}_mlog\]\s+#{vgname}\s+mw\S+/im #attributes start with "m" or "M"
+                    return "mirrored"
+                else
+                    return "disk"
+                end
+            else
+                return "core"
+            end
+        end
+        return nil
+    end
+
+    def mirrorlog=( new_mirror_log_location )
+        # It makes no sense to change this unless we use mirrors.
+        mirror_count = mirror().to_i
+        if mirror_count.to_i > 0
+            current_log_location = mirrorlog().to_s
+            if new_mirror_log_location.to_s != current_log_location
+                #puts "Change mirror log location to #{new_mirror_log_location}..."
+                args = [ '--mirrorlog', new_mirror_log_location ]
+                if @resource[:alloc]
+                    args.push( '--alloc', @resource[:alloc] )
+                end
+                args.push( path )
+                lvconvert( *args )
+            end
+        end
+    end
+
+
+
+
     private
 
     def lvs_pattern
@@ -139,6 +233,11 @@ Puppet::Type.type(:logical_volume).provide :lvm do
 
     def path
         "/dev/#{@resource[:volume_group]}/#{@resource[:name]}"
+    end
+
+    # Device path of only the volume group (does not include the logical volume).
+    def vgpath
+        "/dev/#{@resource[:volume_group]}"
     end
 
 end

--- a/lib/puppet/type/logical_volume.rb
+++ b/lib/puppet/type/logical_volume.rb
@@ -98,6 +98,36 @@ Puppet::Type.newtype(:logical_volume) do
     defaultto :false
   end
 
+
+  newproperty(:mirror) do
+      desc "The number of mirrors of the volume."
+      validate do |value|
+          unless Integer(value).between?(0, 4)
+              raise ArgumentError, "#{value} is not a valid number of mirror copies. Use 0 to un-mirror or 1-4 to set up mirroring."
+          end
+      end
+  end
+  newproperty(:mirrorlog) do
+      desc "How to store the mirror log (core, disk, mirrored)."
+      newvalues( :core, :disk, :mirrored )
+  end
+  newparam(:alloc) do
+      desc "Selects the allocation policy when a command needs to allocate Physical Extents from the Volume Group."
+      newvalues( :anywhere, :contiguous, :cling, :inherit, :normal )
+  end
+  newparam(:no_sync) do
+      desc "An optimization in lvcreate, at least on Linux."
+  end
+  newparam(:region_size) do
+      desc "A mirror is divided into regions of this size (in MB), the mirror log uses this granularity to track which regions are in sync. CAN NOT BE CHANGED on already mirrored volume. Take your mirror size in terabytes and round up that number to the next power of 2, using that number as the -R argument."
+      validate do |value|
+          unless value =~ /^[0-9]+/i
+              raise ArgumentError , "#{value} is not a valid region size in MB."
+          end
+      end
+  end
+
+
   autorequire(:volume_group) do
     @parameters[:volume_group].value
   end

--- a/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
+++ b/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
@@ -19,6 +19,8 @@ describe provider_class do
         @resource.expects(:[]).with(:stripes).returns(nil).at_least_once
         @resource.expects(:[]).with(:stripesize).returns(nil).at_least_once
         @resource.expects(:[]).with(:readahead).returns(nil).at_least_once
+        @resource.expects(:[]).with(:mirror).returns(nil).at_least_once
+        @resource.expects(:[]).with(:alloc).returns(nil).at_least_once        
         @provider.expects(:lvcreate).with('-n', 'mylv', '--size', '1g', 'myvg')
         @provider.create
       end
@@ -33,6 +35,8 @@ describe provider_class do
         @resource.expects(:[]).with(:stripes).returns(nil).at_least_once
         @resource.expects(:[]).with(:stripesize).returns(nil).at_least_once
         @resource.expects(:[]).with(:readahead).returns(nil).at_least_once
+        @resource.expects(:[]).with(:mirror).returns(nil).at_least_once
+        @resource.expects(:[]).with(:alloc).returns(nil).at_least_once        
         @provider.expects(:lvcreate).with('-n', 'mylv', '--size', '1g', 'myvg')
         @provider.create
       end
@@ -47,6 +51,8 @@ describe provider_class do
         @resource.expects(:[]).with(:stripes).returns(nil).at_least_once
         @resource.expects(:[]).with(:stripesize).returns(nil).at_least_once
         @resource.expects(:[]).with(:readahead).returns(nil).at_least_once
+        @resource.expects(:[]).with(:mirror).returns(nil).at_least_once
+        @resource.expects(:[]).with(:alloc).returns(nil).at_least_once        
         @provider.expects(:lvcreate).with('-n', 'mylv', '--extents', '100%FREE', 'myvg')
         @provider.create
       end
@@ -60,6 +66,8 @@ describe provider_class do
         @resource.expects(:[]).with(:stripes).returns(nil).at_least_once
         @resource.expects(:[]).with(:stripesize).returns(nil).at_least_once
         @resource.expects(:[]).with(:readahead).returns(nil).at_least_once
+        @resource.expects(:[]).with(:mirror).returns(nil).at_least_once
+        @resource.expects(:[]).with(:alloc).returns(nil).at_least_once        
         @provider.expects(:lvcreate).with('-n', 'mylv', '--size', '1g', '--extents', '80%vg', 'myvg')
         @provider.create
       end
@@ -73,7 +81,28 @@ describe provider_class do
         @resource.expects(:[]).with(:stripes).returns(nil).at_least_once
         @resource.expects(:[]).with(:stripesize).returns(nil).at_least_once
         @resource.expects(:[]).with(:readahead).returns(nil).at_least_once
+        @resource.expects(:[]).with(:mirror).returns(nil).at_least_once
+        @resource.expects(:[]).with(:alloc).returns(nil).at_least_once        
         @provider.expects(:lvcreate).with('-n', 'mylv', '--size', '1g', 'myvg')
+        @provider.create
+      end
+    end
+    context 'with initial_size and mirroring' do
+      it "should execute 'lvcreate' with '--size' and '--mirrors' and '--mirrorlog' options" do
+        @resource.expects(:[]).with(:name).returns('mylv')
+        @resource.expects(:[]).with(:volume_group).returns('myvg')
+        @resource.expects(:[]).with(:initial_size).returns('1g').at_least_once
+        @resource.expects(:[]).with(:size).returns(nil).at_least_once
+        @resource.expects(:[]).with(:extents).returns(nil).at_least_once
+        @resource.expects(:[]).with(:stripes).returns(nil).at_least_once
+        @resource.expects(:[]).with(:stripesize).returns(nil).at_least_once
+        @resource.expects(:[]).with(:readahead).returns(nil).at_least_once
+        @resource.expects(:[]).with(:mirror).returns('1').at_least_once
+        @resource.expects(:[]).with(:mirrorlog).returns('core').at_least_once
+        @resource.expects(:[]).with(:region_size).returns(nil).at_least_once
+        @resource.expects(:[]).with(:no_sync).returns(nil).at_least_once
+        @resource.expects(:[]).with(:alloc).returns(nil).at_least_once
+        @provider.expects(:lvcreate).with('-n', 'mylv', '--size', '1g', '--mirrors', '1', '--mirrorlog', 'core', 'myvg')
         @provider.create
       end
     end
@@ -90,6 +119,8 @@ describe provider_class do
           @resource.expects(:[]).with(:stripes).returns(nil).at_least_once
           @resource.expects(:[]).with(:stripesize).returns(nil).at_least_once
           @resource.expects(:[]).with(:readahead).returns(nil).at_least_once
+          @resource.expects(:[]).with(:mirror).returns(nil).at_least_once
+          @resource.expects(:[]).with(:alloc).returns(nil).at_least_once        
           @provider.expects(:lvcreate).with('-n', 'mylv', '--size', '1g', 'myvg')
           @provider.create
           @provider.expects(:lvs).with('--noheading', '--unit', 'g', '/dev/myvg/mylv').returns(' 1.00g').at_least_once
@@ -108,6 +139,8 @@ describe provider_class do
           @resource.expects(:[]).with(:stripes).returns(nil).at_least_once
           @resource.expects(:[]).with(:stripesize).returns(nil).at_least_once
           @resource.expects(:[]).with(:readahead).returns(nil).at_least_once
+          @resource.expects(:[]).with(:mirror).returns(nil).at_least_once
+          @resource.expects(:[]).with(:alloc).returns(nil).at_least_once        
           @provider.expects(:lvcreate).with('-n', 'mylv', '--size', '1g', 'myvg')
           @provider.create
           @provider.expects(:lvs).with('--noheading', '--unit', 'g', '/dev/myvg/mylv').returns(' 1.00g').at_least_once
@@ -127,6 +160,8 @@ describe provider_class do
           @resource.expects(:[]).with(:stripesize).returns(nil).at_least_once
           @resource.expects(:[]).with(:readahead).returns(nil).at_least_once
           @resource.expects(:[]).with(:size_is_minsize).returns(:false).at_least_once
+          @resource.expects(:[]).with(:mirror).returns(nil).at_least_once
+          @resource.expects(:[]).with(:alloc).returns(nil).at_least_once        
           @provider.expects(:lvcreate).with('-n', 'mylv', '--size', '1g', 'myvg')
           @provider.create
           @provider.expects(:lvs).with('--noheading', '--unit', 'g', '/dev/myvg/mylv').returns(' 1.00g').at_least_once
@@ -146,6 +181,8 @@ describe provider_class do
           @resource.expects(:[]).with(:stripesize).returns(nil).at_least_once
           @resource.expects(:[]).with(:readahead).returns(nil).at_least_once
           @resource.expects(:[]).with(:size_is_minsize).returns(:true).at_least_once
+          @resource.expects(:[]).with(:mirror).returns(nil).at_least_once
+          @resource.expects(:[]).with(:alloc).returns(nil).at_least_once       
           @provider.expects(:lvcreate).with('-n', 'mylv', '--size', '1g', 'myvg')
           @provider.create
           @provider.expects(:lvs).with('--noheading', '--unit', 'g', '/dev/myvg/mylv').returns(' 1.00g').at_least_once


### PR DESCRIPTION
Resubmitting from a newly rebased branch with a single commit. I retracted the previous pull request which was submitted 4 months ago.

Example for mirrors:

  package { "lvm2":
    ensure => "installed"
  }


  #-----------------------------------------------------------------
  # LVM (Logical Volume Manager) mirrors in puppet by Martin Wangel.
  # Tested locally, and with Amazon EBS volumes on EC2 instances.
  #-----------------------------------------------------------------
  $lvm_file_system="ext4"              # ext4 or xfs, xfs can not be resized by this version of this puppet module
  $vgname="mmvg"                       # name of Volume Group
  $lvname="mmlv"                       # name of Logical Volume
  $devices=["/dev/sdb1","/dev/sdb2"]   # Physical Devices
  $lv_fs_size="2G"                     # Size of Logical Volume

  physical_volume { [$devices]:
      ensure => present
  }
  volume_group { "${vgname}":
      ensure => present,
      physical_volumes => $devices,
      require =>  [ Physical_volume[$devices] ]
  } ->
  logical_volume { "${lvname}":
      ensure => present,
      volume_group => $vgname,
      size => $lv_fs_size,
      mirror => 1,
      mirrorlog => core,
      region_size => 4,
      alloc => normal,
      no_sync => 1
  } ->
  filesystem { "/dev/${vgname}/${lvname}":
      ensure => present,
      fs_type => $lvm_file_system,
  } ->
  mount { "lvm-${vgname}-${lvname}":
    name    => "/u",
    ensure  => mounted,
    device  => "/dev/${vgname}/${lvname}",
    fstype  => $lvm_file_system,
    options => "defaults"
  }