### PR TITLE
Ordering of resources and removal of some defaults in class lvm

### DIFF
--- a/manifests/volume_group.pp
+++ b/manifests/volume_group.pp
@@ -10,7 +10,7 @@ define lvm::volume_group (
 
   physical_volume { $physical_volumes:
     ensure => $ensure,
-  }
+  } ->
 
   volume_group { $name:
     ensure           => $ensure,


### PR DESCRIPTION
Hi, thank you all for this fine module! I have a couple of issues though (and a proposal for solution).

1) When using the lvm class I discovered that the resources are created in random order, so what happens is, the code fails because the vg can't be created on non-existent pv, mkfs can't create file systems on none-existent logvols and so on. This happens and is reproducable when provision several devices. Another example, vgcreate will fail if the drive has an msdos label (in lack of --yes parameter), which happens often, I guess (given eg clearpart --all in anaconda). However, if those drives are pvcreated first, it works. These problems are addressed in manifests/volume_group.pp line 13 and manifests/logical_volume.pp line 58.

2) The other issue is with the creation of logical volumes using the lvm class. By the current design one has to provide size parameter (while extents should suffice), and it's assumed that the user want's a filesystem and mountpoint, and the device mounted afterwards. However, there are several use cases where this is not what the user want's (me). What I want is a logical volume without file system, and therefore no mountpoints or mounting either. I have tried to address these issues here without removing any functionality. I do, however, see a caveat with these changes, depending on whether users are using default values for fs_type and mountpath. There may very well be better ways to do this.

I do apologize if dragging two differing issues into one request is bad karma. My experience in these matters are rather limited for now.