### PR TITLE
Adding mount_ensure parameter to logical volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .*.swp
 Gemfile.lock
 .bundle/
+pkg/

--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -12,6 +12,7 @@ define lvm::logical_volume (
   $mkfs_options      = undef,
   $mountpath         = "/${name}",
   $mountpath_require = false,
+  $mount_ensure      = $ensure ? { 'absent' => absent, default  => mounted, },
   $extents           = undef,
   $stripes           = undef,
   $stripesize        = undef,
@@ -25,11 +26,6 @@ define lvm::logical_volume (
     Mount {
       require => File[$mountpath],
     }
-  }
-
-  $mount_ensure = $ensure ? {
-    'absent' => absent,
-    default  => mounted,
   }
 
   if $ensure == 'present' {


### PR DESCRIPTION
Hi,
I've add a little functionality to allow the creation of a logical volume without mounting it automatically. In some cases, I'd like to create a logical volume but not mounted by default (ex. if I use this logical volume as a disk in Virtual Machine).

So I add a mount_ensure parameter to logical_volume.pp to allow the usage of the Mount resource with ensure => mount, unmounted, present, absent (default: mounted).

My example used to test it:
```
# LVM
class { 'lvm':
  volume_groups    => {
    'vg00' => {
      physical_volumes => [ '/dev/sda2', ],
      logical_volumes  => {
        'present'   => {
                    'size'         => '1G',
                    'mountpath'    => '/mnt/present',
                    'fs_type'      => 'xfs',
                    'mount_ensure' => 'present',
                    },
        'unmounted'  => {
                    'size'         => '1G',
                    'fs_type'      => 'xfs',
                    'mount_ensure' => 'unmounted',
                    },
        'absent'  => {
                    'size'         => '1G',
                    'fs_type'      => 'xfs',
                    'mount_ensure' => 'absent',
                    },
        'mounted' => {
                    'size'         => '1G',
                    'fs_type'      => 'xfs',
                    'mountpath'    => '/mnt/mounted',
                    'mount_ensure' => 'mounted',
                    },
      },
    },
  },
}
```
https://docs.puppetlabs.com/references/latest/type.html#mount-attribute-ensure


Warning, there is still an issue when trying to resize with unmounted partitions. The logical volume is resized but not the filesystem, it cause an error during puppet apply.

Thanks.
Julien Georges <julien.georges@atos.net>