### PR TITLE
Handle undef value in lvm::logical_volume

### DIFF
--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -22,6 +22,10 @@ define lvm::logical_volume (
 
   validate_bool($mountpath_require)
 
+  if ($name == undef) {
+    fail("lvm::logical_volume \$name can't be undefined")
+  }
+
   if $mountpath_require {
     Mount {
       require => File[$mountpath],

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -61,6 +61,11 @@ define lvm::volume (
   $extents = undef,
   $initial_size = undef
 ) {
+
+  if ($name == undef) {
+    fail("lvm::volume \$name can't be undefined")
+  }
+
   case $ensure {
     #
     # Clean up the whole chain.

--- a/manifests/volume_group.pp
+++ b/manifests/volume_group.pp
@@ -8,6 +8,10 @@ define lvm::volume_group (
 
   validate_hash($logical_volumes)
 
+  if ($name == undef) {
+    fail("lvm::volume_group \$name can't be undefined")
+  }
+
   physical_volume { $physical_volumes:
     ensure => $ensure,
   } ->


### PR DESCRIPTION
When an `undef` value is passed as `lvm::logical_volume` name, `mkfs` is called with unwanted command line like

```
Error: Execution of 'mkfs.ext4 /dev/rootvg/' returned 1: mke2fs 1.42.9 (28-Dec-2013)
/dev/rootvg/ is not a block special device.
Proceed anyway? (y,n)
Error: /Stage[main]/Main/Lvm::Logical_volume[undef]/Filesystem[/dev/rootvg/]/ensure: change from absent to present failed: Execution of 'mkfs.ext4 /dev/rootvg/' returned 1: mke2fs 1.42.9 (28-Dec-2013)
/dev/rootvg/ is not a block special device.
Proceed anyway? (y,n)
```

This does not break anything, but we're here protected by `mkfs` that asks for confirmation (this fails in batch mode).

This patch only introduces a stupid test to check that `$name` isn't  `undef`.

My software versions:
* `CentOS 7`
* `puppet v3.7.2`
* `ruby 2.0.0p353`
