### PR TITLE
Adding support of --type attribute with lvcreate

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -61,6 +61,10 @@ Puppet::Type.type(:logical_volume).provide :lvm do
             args.push('--readahead', @resource[:readahead])
         end
 
+        if @resource[:type]
+            args.push('--type', @resource[:type])
+        end
+
         args << @resource[:volume_group]
         lvcreate(*args)
     end

--- a/lib/puppet/type/logical_volume.rb
+++ b/lib/puppet/type/logical_volume.rb
@@ -47,7 +47,7 @@ Puppet::Type.newtype(:logical_volume) do
   end
 
   newparam(:type) do
-    desc "Configures the logical volume type. AIX only"
+    desc "Configures the logical volume type."
   end
 
   newparam(:range) do

--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -18,6 +18,7 @@ define lvm::logical_volume (
   $stripesize        = undef,
   $readahead         = undef,
   $range             = undef,
+  $type              = undef,
 ) {
 
   validate_bool($mountpath_require)
@@ -53,6 +54,7 @@ define lvm::logical_volume (
     readahead    => $readahead,
     extents      => $extents,
     range        => $range,
+    type         => $type,
   }
 
   if $createfs {


### PR DESCRIPTION
Hi,
I've added the support to manage the --type attribute of a logical volume.

Here is the example to test it:
```
class { 'lvm':
  volume_groups    => {
    'vg00' => {
      physical_volumes => [ '/dev/sda2', '/dev/sdb1', '/dev/sdc1' ],
      logical_volumes  => {
        'lv_type' => {
                    'size'      => '1G',
                    'fs_type'   => 'xfs',
                    'mountpath' => '/mnt/type',
                    'type'      => 'raid10',
                    'stripes'   => '3',
                    },
      },
    },
  },
}
```

Here is a copy of the man page of lvcreate
    --type SegmentType
Creates a logical volume with the specified segment type.  Supported types are: cache, cache-pool, error, linear, mirror, raid1, raid4, raid5_la, raid5_ls (= raid5), raid5_ra, raid5_rs, raid6_nc, raid6_nr, raid6_zr (= raid6), raid10, snapshot, striped, thin, thin-pool or zero.   Segment  type  may  have  a  commandline  switch  alias that will enable its use.  When the type is not explicitly specified an implicit type is selected from combination of options: -H|--cache|--cachepool (cache or cachepool), -T|--thin|--thinpool (thin or thin‐pool), -m|--mirrors (raid1 or mirror), -s|--snapshot|-V|--virtualsize (snapshot or thin), -i|--stripes (striped).  Default type is linear.

Thanks
Julien Georges <julien.georges@atos.net>