### PR TITLE
added force parameter to physical_volume

### DIFF
--- a/lib/puppet/provider/physical_volume/lvm.rb
+++ b/lib/puppet/provider/physical_volume/lvm.rb
@@ -3,8 +3,12 @@ Puppet::Type.type(:physical_volume).provide(:lvm) do
 
     commands :pvcreate  => 'pvcreate', :pvremove => 'pvremove', :pvs => 'pvs', :vgs => 'vgs'
 
+    def force
+      @resource[:force] == :true ? '--force' : nil
+    end
+
     def create
-        pvcreate(@resource[:name])
+        pvcreate([force, @resource[:name]].compact)
     end
 
     def destroy

--- a/lib/puppet/type/physical_volume.rb
+++ b/lib/puppet/type/physical_volume.rb
@@ -20,4 +20,9 @@ Puppet::Type.newtype(:physical_volume) do
             end
         end
     end
+    newparam(:force) do
+      desc "Force the creation of the physical volume."
+      defaultto :false
+      newvalues(:true, :false)
+    end
 end

--- a/spec/unit/puppet/provider/physical_volume/lvm_spec.rb
+++ b/spec/unit/puppet/provider/physical_volume/lvm_spec.rb
@@ -11,7 +11,17 @@ describe provider_class do
   describe 'when creating' do
     it "should execute the 'pvcreate'" do
       @resource.expects(:[]).with(:name).returns('/dev/hdx')
-      @provider.expects(:pvcreate).with('/dev/hdx')
+      @resource.expects(:[]).with(:force)
+      @provider.expects(:pvcreate).with(['/dev/hdx'])
+      @provider.create
+    end
+  end
+
+  describe 'when creating with force' do
+    it "should execute the 'pvcreate'" do
+      @resource.expects(:[]).with(:name).returns('/dev/hdx')
+      @resource.expects(:[]).with(:force).returns(:true)
+      @provider.expects(:pvcreate).with(['--force','/dev/hdx'])
       @provider.create
     end
   end


### PR DESCRIPTION
This PR adds a force parameter to the physical_volume resource type resulting in pvcreate being called with the --force flag.

This is particularly useful when the build process leaves disks with digital signatures which causes pvcreate to ask whether or not to wipe them, defaulting to no and failing the resource.  This was my use case and I'm using this patch in production as a workaround

