### PR TITLE
(MODULES-2103) Adds RAL for physical_volume

### DIFF
--- a/spec/unit/puppet/provider/physical_volume/lvm_spec.rb
+++ b/spec/unit/puppet/provider/physical_volume/lvm_spec.rb
@@ -8,6 +8,24 @@ describe provider_class do
     @provider = provider_class.new(@resource)
   end
 
+  pvs_output = <<-EOS
+  PV         VG     Fmt  Attr PSize  PFree
+  /dev/sda2  centos lvm2 a--  19.51g    0
+  /dev/sda3  centos lvm2 a--  10.11g    0
+  EOS
+
+  before :each do
+    @provider.class.stubs(:pvs).returns(pvs_output)
+  end
+
+  describe 'self.instances' do
+    it 'returns an array of physical volumes' do
+      physical_volumes = @provider.class.instances.collect {|x| x.name }
+
+      expect(physical_volumes).to include('/dev/sda2','/dev/sda3')
+    end
+  end
+
   describe 'when creating' do
     it "should execute the 'pvcreate'" do
       @resource.expects(:[]).with(:name).returns('/dev/hdx')


### PR DESCRIPTION
You can now use the RAL to fetch current physical volumes:

```
$ puppet resource physical_volume
physical_volume { '/dev/sda2':
  ensure => 'present',
}
```