### PR TITLE
(maint) Fixes specs for Puppet ~> 2.7.0

### DIFF
--- a/spec/unit/facter/lvm_support_spec.rb
+++ b/spec/unit/facter/lvm_support_spec.rb
@@ -8,20 +8,20 @@ describe 'lvm_support fact' do
 
   context 'when not on Linux' do
     it 'should be set to not' do
-      Facter.fact(:kernel).expects(:value).returns('SunOs')
+      Facter.fact(:kernel).expects(:value).at_least(1).returns('SunOs')
       Facter.value(:lvm_support).should be_nil
     end
   end
 
   context 'when on Linux' do
     before :each do
-      Facter.fact(:kernel).expects(:value).returns('Linux')
+      Facter.fact(:kernel).expects(:value).at_least(1).returns('Linux')
     end
 
     context 'when vgs is absent' do
       it 'should be set to no' do
         Facter::Util::Resolution.stubs('exec') # All other calls
-        Facter::Util::Resolution.expects('which').with('vgs').returns(nil)
+        Facter::Util::Resolution.expects('which').with('vgs').at_least(1).returns(nil)
         Facter.value(:lvm_support).should be_nil
       end
     end
@@ -44,7 +44,7 @@ describe 'lvm_vgs facts' do
 
   context 'when there is no lvm support' do
     it 'should not exist' do
-      Facter.fact(:lvm_support).expects(:value).returns(nil)
+      Facter.fact(:lvm_support).expects(:value).at_least(1).returns(nil)
       Facter.value(:lvm_vgs).should be_nil
     end
   end
@@ -53,8 +53,8 @@ describe 'lvm_vgs facts' do
     context 'when there are no vgs' do
       it 'should be set to 0' do
         Facter::Util::Resolution.stubs('exec') # All other calls
-        Facter::Util::Resolution.expects('exec').with('vgs -o name --noheadings 2>/dev/null').returns(nil)
-        Facter.fact(:lvm_support).expects(:value).returns(true)
+        Facter::Util::Resolution.expects('exec').at_least(1).with('vgs -o name --noheadings 2>/dev/null').returns(nil)
+        Facter.fact(:lvm_support).expects(:value).at_least(1).returns(true)
         Facter.value(:lvm_vgs).should == 0
       end
     end
@@ -62,8 +62,8 @@ describe 'lvm_vgs facts' do
     context 'when there are vgs' do
       it 'should list vgs' do
         Facter::Util::Resolution.stubs('exec') # All other calls
-        Facter::Util::Resolution.expects('exec').with('vgs -o name --noheadings 2>/dev/null').returns("vg0\nvg1")
-        Facter.fact(:lvm_support).expects(:value).returns(true)
+        Facter::Util::Resolution.expects('exec').at_least(1).with('vgs -o name --noheadings 2>/dev/null').returns("vg0\nvg1")
+        Facter.fact(:lvm_support).expects(:value).at_least(1).returns(true)
         Facter.value(:lvm_vgs).should == 2
         Facter.value(:lvm_vg_0).should == 'vg0'
         Facter.value(:lvm_vg_1).should == 'vg1'
@@ -80,7 +80,7 @@ describe 'lvm_pvs facts' do
 
   context 'when there is no lvm support' do
     it 'should not exist' do
-      Facter.fact(:lvm_support).expects(:value).returns(nil)
+      Facter.fact(:lvm_support).expects(:value).at_least(1).returns(nil)
       Facter.value(:lvm_pvs).should be_nil
     end
   end
@@ -89,8 +89,8 @@ describe 'lvm_pvs facts' do
     context 'when there are no pvs' do
       it 'should be set to 0' do
         Facter::Util::Resolution.stubs('exec') # All other calls
-        Facter::Util::Resolution.expects('exec').with('pvs -o name --noheadings 2>/dev/null').returns(nil)
-        Facter.fact(:lvm_support).expects(:value).returns(true)
+        Facter::Util::Resolution.expects('exec').at_least(1).with('pvs -o name --noheadings 2>/dev/null').returns(nil)
+        Facter.fact(:lvm_support).expects(:value).at_least(1).returns(true)
         Facter.value(:lvm_pvs).should == 0
       end
     end
@@ -98,8 +98,8 @@ describe 'lvm_pvs facts' do
     context 'when there are pvs' do
       it 'should list pvs' do
         Facter::Util::Resolution.stubs('exec') # All other calls
-        Facter::Util::Resolution.expects('exec').with('pvs -o name --noheadings 2>/dev/null').returns("pv0\npv1")
-        Facter.fact(:lvm_support).expects(:value).returns(true)
+        Facter::Util::Resolution.expects('exec').at_least(1).with('pvs -o name --noheadings 2>/dev/null').returns("pv0\npv1")
+        Facter.fact(:lvm_support).expects(:value).at_least(1).returns(true)
         Facter.value(:lvm_pvs).should == 2
         Facter.value(:lvm_pv_0).should == 'pv0'
         Facter.value(:lvm_pv_1).should == 'pv1'


### PR DESCRIPTION
@DavidS - "puppet 2.7 calls all facts twice. recommended approach is to add '.at_least(1)' to expectations."