### PR TITLE
Support older versions of facter

### DIFF
--- a/lib/facter/lvm_support.rb
+++ b/lib/facter/lvm_support.rb
@@ -4,8 +4,8 @@ Facter.add('lvm_support') do
   confine :kernel => :linux
 
   setcode do
-    vgdisplay = Facter::Util::Resolution.which('vgs')
-    vgdisplay.nil? ? nil : true
+    `which vgs`
+    $?.success? ? true : nil
   end
 end
 

--- a/spec/unit/facter/lvm_support_spec.rb
+++ b/spec/unit/facter/lvm_support_spec.rb
@@ -21,7 +21,6 @@ describe 'lvm_support fact' do
     context 'when vgs is absent' do
       it 'should be set to no' do
         Facter::Util::Resolution.stubs('exec') # All other calls
-        Facter::Util::Resolution.expects('which').with('vgs').at_least(1).returns(nil)
         Facter.value(:lvm_support).should be_nil
       end
     end


### PR DESCRIPTION
Old facter versions do not support 'Facter::Util::Resolution.which' but they
are still used in LTS distributions like Ubuntu 12.04.
