### PR TITLE
add minor device no and persist options

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -94,6 +94,14 @@ Puppet::Type.type(:logical_volume).provide :lvm do
             args.push('--readahead', @resource[:readahead])
         end
 
+        if @resource[:persistent]
+            args.push('--persistent', @resource[:persistent])
+        end
+
+        if @resource[:minor]
+            args.push('--minor', @resource[:minor])
+        end
+
         args << @resource[:volume_group]
         lvcreate(*args)
     end

--- a/lib/puppet/type/logical_volume.rb
+++ b/lib/puppet/type/logical_volume.rb
@@ -46,6 +46,24 @@ Puppet::Type.newtype(:logical_volume) do
     end
   end
 
+  newparam(:persistent) do
+    desc "Set to y to make the minor number specified persistent"
+    validate do |value|
+      unless value =~ /^[yn]$/i
+        raise ArgumentError , "#{value} is not a valid value for persistence"
+      end
+    end
+  end
+
+  newparam(:minor) do
+    desc "Set the minor number"
+    validate do |value|
+      unless value =~ /^(?:[0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$/
+        raise ArgumentError , "#{value} is not a valid value for minor"
+      end
+    end
+  end
+
   newparam(:type) do
     desc "Configures the logical volume type. AIX only"
   end

--- a/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
+++ b/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
@@ -39,6 +39,8 @@ describe provider_class do
         @resource.expects(:[]).with(:readahead).returns(nil).at_least_once
         @resource.expects(:[]).with(:mirror).returns(nil).at_least_once
         @resource.expects(:[]).with(:alloc).returns(nil).at_least_once
+        @resource.expects(:[]).with(:persistent).returns(nil).at_least_once
+        @resource.expects(:[]).with(:minor).returns(nil).at_least_once
         @provider.expects(:lvcreate).with('-n', 'mylv', '--size', '1g', 'myvg')
         @provider.create
       end
@@ -55,6 +57,8 @@ describe provider_class do
         @resource.expects(:[]).with(:readahead).returns(nil).at_least_once
         @resource.expects(:[]).with(:mirror).returns(nil).at_least_once
         @resource.expects(:[]).with(:alloc).returns(nil).at_least_once
+        @resource.expects(:[]).with(:persistent).returns(nil).at_least_once
+        @resource.expects(:[]).with(:minor).returns(nil).at_least_once
         @provider.expects(:lvcreate).with('-n', 'mylv', '--size', '1g', 'myvg')
         @provider.create
       end
@@ -71,6 +75,8 @@ describe provider_class do
         @resource.expects(:[]).with(:readahead).returns(nil).at_least_once
         @resource.expects(:[]).with(:mirror).returns(nil).at_least_once
         @resource.expects(:[]).with(:alloc).returns(nil).at_least_once
+        @resource.expects(:[]).with(:persistent).returns(nil).at_least_once
+        @resource.expects(:[]).with(:minor).returns(nil).at_least_once
         @provider.expects(:lvcreate).with('-n', 'mylv', '--extents', '100%FREE', 'myvg')
         @provider.create
       end
@@ -86,6 +92,8 @@ describe provider_class do
         @resource.expects(:[]).with(:readahead).returns(nil).at_least_once
         @resource.expects(:[]).with(:mirror).returns(nil).at_least_once
         @resource.expects(:[]).with(:alloc).returns(nil).at_least_once
+        @resource.expects(:[]).with(:persistent).returns(nil).at_least_once
+        @resource.expects(:[]).with(:minor).returns(nil).at_least_once
         @provider.expects(:lvcreate).with('-n', 'mylv', '--size', '1g', '--extents', '80%vg', 'myvg')
         @provider.create
       end
@@ -101,6 +109,8 @@ describe provider_class do
         @resource.expects(:[]).with(:readahead).returns(nil).at_least_once
         @resource.expects(:[]).with(:mirror).returns(nil).at_least_once
         @resource.expects(:[]).with(:alloc).returns(nil).at_least_once
+        @resource.expects(:[]).with(:persistent).returns(nil).at_least_once
+        @resource.expects(:[]).with(:minor).returns(nil).at_least_once
         @provider.expects(:lvcreate).with('-n', 'mylv', '--size', '1g', 'myvg')
         @provider.create
       end
@@ -120,7 +130,26 @@ describe provider_class do
         @resource.expects(:[]).with(:region_size).returns(nil).at_least_once
         @resource.expects(:[]).with(:no_sync).returns(nil).at_least_once
         @resource.expects(:[]).with(:alloc).returns(nil).at_least_once
+        @resource.expects(:[]).with(:persistent).returns(nil).at_least_once
+        @resource.expects(:[]).with(:minor).returns(nil).at_least_once
         @provider.expects(:lvcreate).with('-n', 'mylv', '--size', '1g', '--mirrors', '1', '--mirrorlog', 'core', 'myvg')
+        @provider.create
+      end
+    end
+    context 'with persistent minor block device' do
+      it "should execute 'lvcreate' with '--persistent y' and '--minor 100' option" do
+        @resource.expects(:[]).with(:name).returns('mylv')
+        @resource.expects(:[]).with(:volume_group).returns('myvg')
+        @resource.expects(:[]).with(:size).returns('1g').at_least_once
+        @resource.expects(:[]).with(:persistent).returns('y').at_least_once
+        @resource.expects(:[]).with(:minor).returns('100').at_least_once
+        @resource.expects(:[]).with(:extents).returns(nil).at_least_once
+        @resource.expects(:[]).with(:stripes).returns(nil).at_least_once
+        @resource.expects(:[]).with(:stripesize).returns(nil).at_least_once
+        @resource.expects(:[]).with(:readahead).returns(nil).at_least_once
+        @resource.expects(:[]).with(:mirror).returns(nil).at_least_once
+        @resource.expects(:[]).with(:alloc).returns(nil).at_least_once
+        @provider.expects(:lvcreate).with('-n', 'mylv', '--size', '1g', '--persistent', 'y', '--minor', '100', 'myvg')
         @provider.create
       end
     end
@@ -139,6 +168,8 @@ describe provider_class do
           @resource.expects(:[]).with(:readahead).returns(nil).at_least_once
           @resource.expects(:[]).with(:mirror).returns(nil).at_least_once
           @resource.expects(:[]).with(:alloc).returns(nil).at_least_once
+          @resource.expects(:[]).with(:persistent).returns(nil).at_least_once
+          @resource.expects(:[]).with(:minor).returns(nil).at_least_once
           @provider.expects(:lvcreate).with('-n', 'mylv', '--size', '1g', 'myvg')
           @provider.create
           @provider.expects(:lvs).with('--noheading', '--unit', 'g', '/dev/myvg/mylv').returns(' 1.00g').at_least_once
@@ -159,6 +190,8 @@ describe provider_class do
           @resource.expects(:[]).with(:readahead).returns(nil).at_least_once
           @resource.expects(:[]).with(:mirror).returns(nil).at_least_once
           @resource.expects(:[]).with(:alloc).returns(nil).at_least_once
+          @resource.expects(:[]).with(:persistent).returns(nil).at_least_once
+          @resource.expects(:[]).with(:minor).returns(nil).at_least_once
           @provider.expects(:lvcreate).with('-n', 'mylv', '--size', '1g', 'myvg')
           @provider.create
           @provider.expects(:lvs).with('--noheading', '--unit', 'g', '/dev/myvg/mylv').returns(' 1.00g').at_least_once
@@ -180,6 +213,8 @@ describe provider_class do
           @resource.expects(:[]).with(:size_is_minsize).returns(:false).at_least_once
           @resource.expects(:[]).with(:mirror).returns(nil).at_least_once
           @resource.expects(:[]).with(:alloc).returns(nil).at_least_once
+          @resource.expects(:[]).with(:persistent).returns(nil).at_least_once
+          @resource.expects(:[]).with(:minor).returns(nil).at_least_once
           @provider.expects(:lvcreate).with('-n', 'mylv', '--size', '1g', 'myvg')
           @provider.create
           @provider.expects(:lvs).with('--noheading', '--unit', 'g', '/dev/myvg/mylv').returns(' 1.00g').at_least_once
@@ -201,6 +236,8 @@ describe provider_class do
           @resource.expects(:[]).with(:size_is_minsize).returns(:true).at_least_once
           @resource.expects(:[]).with(:mirror).returns(nil).at_least_once
           @resource.expects(:[]).with(:alloc).returns(nil).at_least_once
+          @resource.expects(:[]).with(:persistent).returns(nil).at_least_once
+          @resource.expects(:[]).with(:minor).returns(nil).at_least_once
           @provider.expects(:lvcreate).with('-n', 'mylv', '--size', '1g', 'myvg')
           @provider.create
           @provider.expects(:lvs).with('--noheading', '--unit', 'g', '/dev/myvg/mylv').returns(' 1.00g').at_least_once


### PR DESCRIPTION
I needed to create LVs with persistent block device IDs (for use a ext4 journal devices)

This change surfaces the --persistence and --minor options to the lvcreate command.