### PR TITLE
Make size_is_minsize usable from lvm::logical_volume

### DIFF
--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -18,6 +18,7 @@ define lvm::logical_volume (
   $stripesize        = undef,
   $readahead         = undef,
   $range             = undef,
+  $size_is_minsize   = undef,
 ) {
 
   validate_bool($mountpath_require)
@@ -74,6 +75,7 @@ define lvm::logical_volume (
     readahead    => $readahead,
     extents      => $extents,
     range        => $range,
+    size_is_minsize => $size_is_minsize
   }
 
   if $createfs {

--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -66,15 +66,15 @@ define lvm::logical_volume (
   }
 
   logical_volume { $name:
-    ensure       => $ensure,
-    volume_group => $volume_group,
-    size         => $size,
-    initial_size => $initial_size,
-    stripes      => $stripes,
-    stripesize   => $stripesize,
-    readahead    => $readahead,
-    extents      => $extents,
-    range        => $range,
+    ensure          => $ensure,
+    volume_group    => $volume_group,
+    size            => $size,
+    initial_size    => $initial_size,
+    stripes         => $stripes,
+    stripesize      => $stripesize,
+    readahead       => $readahead,
+    extents         => $extents,
+    range           => $range,
     size_is_minsize => $size_is_minsize
   }
 


### PR DESCRIPTION
Currently lvm::logical_volume can not be invoked with the parameter size_is_minsize. This pr makes it configureable:
~~~puppet
node 'default' {
  lvm::logical_volume {'test2':
    volume_group   => "vgd_${hostname}",
    size           =>'1M',
    mountpath => '/mnt/test2',
    pass => 2,
    dump => 1,
    size_is_minsize => 'true',
  }
}
~~~