### PR TITLE
Adding option package management and mountpoint management

### DIFF
--- a/manifests/config_mountpoints.pp
+++ b/manifests/config_mountpoints.pp
@@ -1,4 +1,4 @@
-class lvm::config (
+class lvm::config_mountpoints (
   $mountpoints        = $::lvm::mountpoints,
 ) {
 

--- a/manifests/config_mountpoints.pp
+++ b/manifests/config_mountpoints.pp
@@ -1,0 +1,17 @@
+class lvm::config (
+  $mountpoints        = $::lvm::mountpoints,
+) {
+
+  if ($mountpoints) {
+
+    $mountpoint_defaults = {
+      ensure => directory,
+      mode   => '0755',
+      owner  => 'root',
+      group  => 'root',
+    }
+
+    create_resources(file, $mountpoints, $mountpoint_defaults)
+  }
+
+}

--- a/manifests/config_volumes.pp
+++ b/manifests/config_volumes.pp
@@ -1,0 +1,7 @@
+class lvm::config_volumes (
+  $volume_groups = $::lvm::volume_groups,
+) {
+
+  create_resources('::lvm::volume_group', $volume_groups)
+
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,5 +14,5 @@ class lvm (
   class { '::lvm::install':             } ->
   class { '::lvm::config_mountpoints':  } ->
   class { '::lvm::config_volumes':      } ->
-  Class['Lvm']
+  Class['lvm']
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,8 +11,11 @@ class lvm (
   validate_bool($manage_package)
   validate_string($package_name)
 
-  class { '::lvm::install':             } ->
-  class { '::lvm::config_mountpoints':  } ->
-  class { '::lvm::config_volumes':      } ->
-  Class['lvm']
+  contain '::lvm::install'
+  contain '::lvm::config_mountpoints'
+  contain '::lvm::config_volumes'
+
+  Class ['::lvm::install'] ->
+  Class ['::lvm::config_mountpoints'] ->
+  Class ['::lvm::config_volumes']
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,10 +1,18 @@
-# == Class: lvm
-#
 class lvm (
-  $volume_groups = {},
-) {
+  $manage_package = $::lvm::params::manage_package,
+  $package_name   = $::lvm::params::package_name,
+  $package_ensure = $::lvm::params::package_ensure,
+  $mountpoints    = $::lvm::params::mountpoints,
+  $volume_groups  = $::lvm::params::volume_groups,
+) inherits ::lvm::params {
 
   validate_hash($volume_groups)
+  validate_hash($mountpoints)
+  validate_bool($manage_package)
+  validate_string($package_name)
 
-  create_resources('lvm::volume_group', $volume_groups)
+  class { '::lvm::install':             } ->
+  class { '::lvm::config_mountpoints':  } ->
+  class { '::lvm::config_volumes':      } ->
+  Class['::lvm']
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,5 +14,5 @@ class lvm (
   class { '::lvm::install':             } ->
   class { '::lvm::config_mountpoints':  } ->
   class { '::lvm::config_volumes':      } ->
-  Class['::lvm']
+  Class['Lvm']
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,15 @@
+class lvm::install (
+  $manage_package  = $::lvm::manage_package,
+  $package_name    = $::lvm::package_name,
+  $package_ensure  = $::lvm::package_ensure,
+){
+
+  if ($manage_package) {
+
+    package { $package_name :
+      ensure => $package_ensure,
+    }
+
+  }
+
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,16 @@
+class lvm::params {
+
+  case $::kernel {
+    'Linux': {
+      $manage_package = false
+      $package_name   = 'lvm2'
+      $package_ensure = 'installed'
+      $mountpoints    = {}
+      $volume_groups  = {}
+    }
+
+  default: {
+      fail("The ${module_name} module is not supported on an ${::osfamily} based system.")
+    }
+  }
+}


### PR DESCRIPTION
Added some support for specifying a package name and version to be ensured against. The default is `lvm2` and `installed` if `manage_package` is set to true.

Added support for specifying mount points as a hash of `file` objects. The user only needs to specify a path to the intended mountpoint directory. Default owner/group and permissions can be overridden if required. 

The params defaults are set such that these changes should be non-breaking to existing users.