### PR TITLE
(logical_volume) Fix regex on new_size and coerce to float instead of int

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -132,12 +132,12 @@ Puppet::Type.type(:logical_volume).provide :lvm do
         current_size = size()
 
         if current_size =~ /(\d+\.{0,1}\d{0,2})(#{lvm_size_units_match})/i
-            current_size_bytes = $1.to_i
+            current_size_bytes = $1.to_f
             current_size_unit  = $2.upcase
         end
 
-        if new_size =~ /(\d+)(#{lvm_size_units_match})/i
-            new_size_bytes = $1.to_i
+        if new_size =~ /(\d+\.{0,1}\d{0,2})(#{lvm_size_units_match})/i
+            new_size_bytes = $1.to_f
             new_size_unit  = $2.upcase
         end
 


### PR DESCRIPTION
1) The size property allows floating point values, but in the provider we
coerce the size string reported by lvm to an int, effectively
ignoring the decimal part at resize.

2) The regex used to extract size and unit from the desired size
doesn't match floating point values. It ends up matching the decimal
part of a floating point value in the first backreference.
This leads to the following issue breaking resizes when a floating point
value for size is set:

"""
Error: Decreasing the size requires manual intervention (103.06G <
71.06G)
Error:
/Stage[main]/S_puppetdb::Lvconfig/Profile_lvm::Fs_on_lv[root]/Logical_volume[root]/size:
change from 71.06G to 103.06G failed: Decreasing the size requires
manual intervention (103.06G < 71.06G)
"""

Because new_size_bytes is actually set to only the decimal part: 6

This commit updates the regex for new_size to match floating point values, and
coerces the sizes reported by lvm to float instead of int.