### PR TITLE
Add parameter lvm_device_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,14 @@ Logical volume size can be extended, but not reduced -- this is for
 safety, as manual intervention is probably required for data
 migration, etc.
 
+### Size of the Logical Volumes
+
+Desired size of the partition set in parameter size may be altered by 
+calculation that incorporates volume group extent size. If it is altered it is 
+altered towards the higher value. The change may be greater where VG extent 
+size is larger compared to size of the partition. It is not an invention of 
+the module, it is caused by the design of LVM.
+
 Contributors
 =======
 Bruce Williams <bruce@codefluency.com>

--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -11,6 +11,7 @@ define lvm::logical_volume (
   $fs_type           = 'ext4',
   $mkfs_options      = undef,
   $mountpath         = "/${name}",
+  $lvm_device_path   = "/dev/${volume_group}/${name}",
   $mountpath_require = false,
   $createfs          = true,
   $extents           = undef,
@@ -26,8 +27,6 @@ define lvm::logical_volume (
   if ($name == undef) {
     fail("lvm::logical_volume \$name can't be undefined")
   }
-
-  $lvm_device_path = "/dev/${volume_group}/${name}"
 
   if $mountpath_require and $fs_type != 'swap' {
     Mount {


### PR DESCRIPTION
While using multipath driver it is convenient to use different
device name - /dev/mapper/... instead /dev/\<volume_group\>/...
So variable lvm_device_path is moved to parameters with expected
value set as a default.