### PR TITLE
Added support for volumes not mounted by lvm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ resources out yourself.
    -  `:core`
    -  `:disk`
    -  `:mirrored`
+* mounted - If puppet should mount the volume. This only affects what puppet will do, and not what will be mounted at boot-time.
 * no_sync (Parameter) - An optimization in lvcreate, at least on Linux.
 * persistent (Parameter) - Set to true to make the block device persistent
 * readahead (Parameter) - The readahead count to use for the new logical volume.

--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -12,6 +12,7 @@ define lvm::logical_volume (
   $mkfs_options      = undef,
   $mountpath         = "/${name}",
   $mountpath_require = false,
+  $mounted           = true,
   $createfs          = true,
   $extents           = undef,
   $stripes           = undef,
@@ -52,7 +53,10 @@ define lvm::logical_volume (
     $fixed_dump      = $dump
     $mount_ensure    = $ensure ? {
       'absent' => absent,
-      default  => mounted,
+      default  => $mounted ? {
+        true      => mounted,
+        false     => present,
+      }
     }
   }
 

--- a/spec/unit/classes/lvm_spec.rb
+++ b/spec/unit/classes/lvm_spec.rb
@@ -51,6 +51,30 @@ describe 'lvm', :type => :class do
     it { should contain_mount('/var/backups') }
   end
 
+  describe 'without mount' do
+    let(:params) do
+      {
+        :volume_groups => {
+          'myvg' => {
+            'physical_volumes' => [ '/dev/sda2', ],
+            'logical_volumes'  => {
+              'not_mounted' => {
+                'size'              => '5G',
+                'mounted'           => false,
+                'mountpath'         => '/mnt/not_mounted',
+                'mountpath_require' => true
+              }
+            }
+          }
+        }
+      }
+    end
+
+    it { should contain_mount('/mnt/not_mounted').with({
+        :ensure       => 'present'
+    }) }
+  end
+
   describe 'with a swap volume' do
     let(:params) do
       {


### PR DESCRIPTION
This patch allows a logical_volume to be made ready, but not mounted. 
This allows for the actual mount to be done after data is migrated to the new volume.