### PR TITLE
force ext4 filesystems so we can use whole disks

### DIFF
--- a/lib/puppet/provider/filesystem/lvm.rb
+++ b/lib/puppet/provider/filesystem/lvm.rb
@@ -22,7 +22,7 @@ Puppet::Type.type(:filesystem).provide :lvm do
     end
 
     def mkfs(fs_type)
-        mkfs_params = { "reiserfs" => "-q" }
+        mkfs_params = { "reiserfs" => "-q", "ext4" => "-F" }
 
         mkfs_cmd = @resource[:mkfs_cmd] != nil ?
                      [@resource[:mkfs_cmd]] :


### PR DESCRIPTION
Hello

I use the filesystem resource to manage whole disks rather than partitions and mkfs.ext4 gives a y/n question unless the force (-F) flag is given.  this patch does that.

Thanks.

Neil
