### PR TITLE
(MODULES-2790) Improve README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,8 @@
-Puppet LVM Module
-=================
+# Puppet LVM Module
 
 Provides Logical Resource Management (LVM) features for Puppet.
 
-History
--------
-2012-08-14 : rcoleman
-
-  * Version 0.1.1 : More style-guide compliant, fixed a closing } bug and updated README
-
-2011-08-30 : matthaus
-
-  * Version 0.1.0 : Refactor tests, update readme, repackage for module forge
-
-2011-08-02 : zyv
-
-  * Make it possible to omit the file system type for lmv::volume
-
-2011-07-12 : frimik
-
-  * Allow filesystem type to accept parameters [:options]
-
-2011-06-30 : windowsrefund
-
-  * lvm::volume now uses defined() in order to avoid declaring duplicate
-    physical_volume and/or volume_group resources.
-
-  * logical_volume provider now calls dmsetup when removing a volume.
-
-Usage
------
+## Usage Examples
 
 This module provides four resource types (and associated providers):
 `volume_group`, `logical_volume`, `physical_volume`, and `filesystem`.
@@ -108,7 +81,7 @@ This could be really convenient when used with hiera:
 include ::lvm
 ```
 and
-```
+```yaml
 ---
 lvm::volume_groups:
   myvg:
@@ -132,8 +105,9 @@ lvm::volume_groups:
         mountpath_require: true
 ```
 
+
+
 Except that in the latter case you cannot specify create options.
-=======
 If you want to omit the file system type, but still specify the size of the
 logical volume, i.e. in the case if you are planning on using this logical
 volume as a swap partition or a block device for a virtual machine image, you
@@ -142,8 +116,7 @@ need to use a hash to pass the parameters to the definition.
 If you need a more complex configuration, you'll need to build the
 resources out yourself.
 
-Optional Values
----------------
+## Optional Values
   The `unless_vg` (physical_volume) and `createonly` (volume_group) will check 
   to see if "myvg" exists.  If "myvg" does exist then they will not modify
   the physical volume or volume_group.  This is usefull if you environment
@@ -151,7 +124,7 @@ Optional Values
   or moves.
  
   Example:
-
+```puppet
     physical_volume { "/dev/hdc":
         ensure => present,
         unless_vg => "myvg"
@@ -161,9 +134,132 @@ Optional Values
         physical_volumes => "/dev/hdc",
         createonly => true
     }
+```
 
-Limitations
------------
+## Type Documentation
+
+### filesystem
+
+* name (Parameter) (Namevar)
+* ensure (Property)
+* fs_type (Parameter) - The file system type. eg. ext3.
+* mkfs_cmd (Parameter) - Command to use to create the file system. Defaults to `mkswap` for `fs_type=swap`, otherwise `mkfs.{fs_type}`
+* options (Parameter) - Params for the mkfs command. eg. `-l internal,agcount=x`
+
+### logical_volume
+
+* name (Parameter) (Namevar) - The name of the logical volume. This is the unqualified name and will be automatically added to the volume group’s device path (e.g., ‘/dev/$vg/$lv’).
+* ensure (Property)
+* alloc (Parameter) - Selects the allocation policy when a command needs to allocate Physical Extents from the Volume Group. Allowed Values:
+    - `:anywhere`
+    - `:contiguous`
+    - `:cling`
+    - `:inherit`
+    - `:normal`
+* extents (Parameter) - The number of logical extents to allocate for the new logical volume. Set to undef to use all available space
+* initial_size (Parameter) - The initial size of the logical volume. This will only apply to newly-created volumes
+* minor (Parameter) - Set the minor number
+* mirror (Property) - The number of mirrors of the volume.
+* mirrorlog (Property) - How to store the mirror log (core, disk, mirrored).  Allowed Values:
+   -  `:core`
+   -  `:disk`
+   -  `:mirrored`
+* no_sync (Parameter) - An optimization in lvcreate, at least on Linux.
+* persistent (Parameter) - Set to true to make the block device persistent
+* readahead (Parameter) - The readahead count to use for the new logical volume.
+* region_size (Parameter) - A mirror is divided into regions of this size (in MB), the mirror log uses this granularity to track which regions are in sync. CAN NOT BE CHANGED on already mirrored volume. Take your mirror size in terabytes and round up that number to the next power of 2, using that number as the -R argument.
+* size (Property) - The size of the logical volume. Set to undef to use all available space
+* size_is_minsize (Parameter) Default value: `:false` - Set to true if the ‘size’ parameter specified, is just the minimum size you need (if the LV found is larger then the size requests this is just logged not causing a FAIL)
+* stripes (Parameter) - The number of stripes to allocate for the new logical volume.
+* stripesize (Parameter) - The stripesize to use for the new logical volume.
+* volume_group (Parameter) - The volume group name associated with this logical volume. This will automatically set this volume group as a dependency, but it must be defined elsewhere using the volume_group resource type.
+
+### physical_volume
+
+* name (Parameter) (Namevar)
+* ensure (Property) -
+* force (Parameter) Default value: `:false` - Force the creation without any confirmation. Allowed Values:
+   - `:true`
+   - `:false`
+* unless_vg (Parameter) - Do not do anything if the VG already exists. The value should be the name of the volume group to check for.
+
+### volume_group
+
+* name (Parameter) (Namevar) - The name of the volume group.
+* ensure (Property)
+* createonly (Parameter) Default value: :false - If set to true the volume group will be created if it does not exist. If the volume group does exist no action will be taken. Defaults to `false`.  Allowed Values:
+   - `:true`
+   - `:false`
+* physical_volumes (Property) - The list of physical volumes to be included in the volume group; this will automatically set these as dependencies, but they must be defined elsewhere using the physical_volume resource type.
+
+## AIX Specific Type Documentation
+
+
+There are a number of AIX specific parameters and properties. The regular
+parameters documented above also apply to AIX systems.
+
+
+### filesystem
+
+* accounting (Parameter) - Specify accounting subsystem support, Allowed Values:
+    * `:true`
+    * `:false`
+* ag_size (Parameter) - Specify the allocation group size in megabytes,   Allowed Values:
+    * `/\d+/`
+* agblksize (Parameter) - JFS2 block size in bytes,   Allowed Values: 
+    * `/\d+/`
+* atboot (Parameter) - Specify whether the file system is mounted at boot time, Allowed Values:
+    * `:true`
+    * `:false`
+* compress (Parameter) - Data compression, LZ or no. Allowed Values:
+    * `:LG`
+    * `:no`
+* device (Parameter) - Device to create the filesystem on, this can be a device or a logical volume.
+* encrypted (Parameter) - Specify and encrypted filesystem. Allowed Values:
+    * `:true`
+    * `:false`
+* extended_attributes (Parameter) - Format to be used to store extended attributes. Allowed Values:
+    * `:v1`
+    * `:v2`
+* frag (Parameter) - JFS fragment size in bytes.  Allowed Values:
+    * `/\d+/`
+* initial_size (Parameter) - Initial size of the filesystem, Used only for resource creation, when using this option Puppet will not manage or maintain the size. To resize filesystems see the size property.
+* isnapshot (Parameter) - Specify whether the filesystem supports internal snapshots, Allowed Values:
+    * `:true`
+    * `:false`
+* large_files (Parameter) - Large file enabled file system. Allowed Values:
+    * `:true`
+    * `:false`
+* log_partitions (Parameter) - Specify the size of the log logical volume as number of logical partitions,
+* logname (Parameter) - Configure the log logical volume.
+* logsize (Parameter) - Size for an inline log in MB, Allowed Values:
+    * `/\d+/`
+* maxext (Parameter) - Size of a file extent in file system blocks, Allowed Values:
+    * `/\d+/`
+* mount_options (Parameter) - Specify the options to be passed to the mount command.
+* mountgroup (Parameter) - Mount group for the filesystem,
+* mountguard (Parameter) - Enable the mountguard. Allowed Values:
+    * `:true`
+    * `:false`
+* nbpi (Parameter) - Bytes per inode. Allowed Values:
+    * `/\d+/`
+* nodename (Parameter) - Specify the remote host where the filesystem resides.
+* perms (Parameter) - Permissions for the filesystem, Allowed Values:
+    * `:ro`
+    * `:rw`
+* size (Property) - Configures the size of the filesystem. Supports filesystem resizing. The size will be rounded up to the nearest multiple of the partition size.
+* vix (Parameter) - Specify that the file system can allocate inode extents smaller than the default, Allowed Values:
+    * `:true`
+    * `:false`
+* volume_group (Parameter) - Volume group that the file system should be greated on.
+
+### logical_volume
+
+* range (Parameter) - Sets the inter-physical volume allocation policy. AIX only
+* type (Parameter) - Configures the logical volume type. AIX only
+
+
+## Limitations
 
 ### Namespacing
 
@@ -187,8 +283,9 @@ Logical volume size can be extended, but not reduced -- this is for
 safety, as manual intervention is probably required for data
 migration, etc.
 
-Contributors
-=======
+
+# Contributors
+
 Bruce Williams <bruce@codefluency.com>
 
 Daniel Kerwin <github@reductivelabs.com>
@@ -223,4 +320,4 @@ Raphaël Pinson <raphael.pinson@camptocamp.com>
 
 Garrett Honeycutt <code@garretthoneycutt.com>
 
-<a href="https://github.com/bmjen/puppetlabs-lvm/graphs/contributors">More Contributers</a>
+[More Contributers](https://github.com/puppetlabs/puppetlabs-lvm/graphs/contributors)


### PR DESCRIPTION
~~Also splits out AIX specific attribute documentation into its own file.~~
Makes the README style more consistent.