### PR TITLE
Fix issue with using force method as pvcreate argument

### DIFF
--- a/lib/puppet/provider/physical_volume/lvm.rb
+++ b/lib/puppet/provider/physical_volume/lvm.rb
@@ -11,11 +11,11 @@ Puppet::Type.type(:physical_volume).provide(:lvm) do
     end
 
     def create
-        pvcreate(force, @resource[:name])
+      create_physical_volume(@resource[:name])
     end
 
     def destroy
-        pvremove(@resource[:name])
+      pvremove(@resource[:name])
     end
 
     def exists?
@@ -71,9 +71,15 @@ Puppet::Type.type(:physical_volume).provide(:lvm) do
       physical_volumes_properties
     end
 
-    def force
-      return '--force' if @resource[:force] == :true
-      nil
+    private
+
+    def create_physical_volume(path)
+      args = []
+      if @resource[:force] == :true
+        args.push('--force')
+      end
+      args << path
+        pvcreate(*args)
     end
 
 end

--- a/spec/unit/puppet/provider/physical_volume/lvm_spec.rb
+++ b/spec/unit/puppet/provider/physical_volume/lvm_spec.rb
@@ -27,10 +27,9 @@ describe provider_class do
   end
 
   describe 'when creating' do
-    it "should execute the 'pvcreate'" do
+    it "should execute the 'create_physical_volume'" do
       @resource.expects(:[]).with(:name).returns('/dev/hdx')
-      @resource.expects(:[]).with(:force)
-      @provider.expects(:pvcreate).with(nil, '/dev/hdx')
+      @provider.expects(:create_physical_volume).with('/dev/hdx')
       @provider.create
     end
   end


### PR DESCRIPTION
passing a blank argument (when force => false) to the pvcreate method causes errors:

    ~]# puppet resource --debug --trace physical_volume /dev/sdc ensure=present
    Debug: Executing: '/sbin/pvs /dev/sdc'
    Debug: Executing: '/sbin/pvcreate  /dev/sdc'
    Error: Execution of '/sbin/pvcreate  /dev/sdc' returned 5: Device  not found (or ignored by filtering).
      Physical volume "/dev/sdc" successfully created

Which appear to be related to the insertion of the extra "nil" argument. Note the extra space in `/sbin/pvcreate  /dev/sdc`. This shouldn't matter if the command is executed 'as-is' on the commandline but there appears to possibly be some sort of quoting or grouping going on such that the command is literally `/sbin/pvcreate ' /dev/sdc'`, which causes an error. I'm not sure why the PV is still created successfully despite the error, however.

This PR should fix the issue.