### PR TITLE
Added support to the resize of a logical volume with swap

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -6,6 +6,9 @@ Puppet::Type.type(:logical_volume).provide :lvm do
              :lvextend   => 'lvextend',
              :lvs        => 'lvs',
              :resize2fs  => 'resize2fs',
+             :mkswap     => 'mkswap',
+             :swapoff    => 'swapoff',
+             :swapon     => 'swapon',
              :umount     => 'umount',
              :blkid      => 'blkid',
              :dmsetup    => 'dmsetup',
@@ -188,6 +191,8 @@ Puppet::Type.type(:logical_volume).provide :lvm do
               resize2fs( path) || fail( "Cannot resize file system to size #{new_size} because resize2fs failed." )
             elsif blkid_type =~ /\bTYPE=\"(xfs)\"/
               xfs_growfs( path) || fail( "Cannot resize filesystem to size #{new_size} because xfs_growfs failed." )
+            elsif blkid_type =~ /\bTYPE=\"(swap)\"/
+              swapoff( path) && mkswap( path) && swapon( path) || fail( "Cannot resize swap to size #{new_size} because mkswap failed." )
             end
 
         end


### PR DESCRIPTION
Hello,

I noticed that the provider did not extended automatically the logical volume for a swap partition, so I've done this small change that follow the best practive for doing it.
swapoff (turn off swap)
mkswap (format the logical volume again, so it uses the whole size)
swapon (put swap back online).

Best Regards