### PR TITLE
sanitize vg names within fact names

### DIFF
--- a/lib/facter/lvm_support.rb
+++ b/lib/facter/lvm_support.rb
@@ -30,8 +30,9 @@ end
 # lvm_vg_[0-9]+
 #   VG name by index
 vg_list.each_with_index do |vg, i|
+  vgn = vg.gsub('-','_')
   Facter.add("lvm_vg_#{i}") { setcode { vg } }
-  Facter.add("lvm_vg_#{vg}_pvs") do
+  Facter.add("lvm_vg_#{vgn}_pvs") do
     setcode do
       pvs = Facter::Core::Execution.execute("vgs -o pv_name #{vg} 2>/dev/null", timeout: 30)
       res = nil

--- a/spec/unit/facter/lvm_support_spec.rb
+++ b/spec/unit/facter/lvm_support_spec.rb
@@ -72,6 +72,18 @@ describe 'lvm_vgs facts' do
         Facter.value(:lvm_vg_vg0_pvs).should == '/dev/pv2,/dev/pv3'
         Facter.value(:lvm_vg_vg1_pvs).should == '/dev/pv0'
       end
+      it 'should sanitize vg names' do
+        Facter::Util::Resolution.stubs('exec') # All other calls
+        Facter::Util::Resolution.expects('exec').at_least(1).with('vgs -o name --noheadings 2>/dev/null').returns("vg0\nvg-1")
+        Facter::Util::Resolution.expects('exec').at_least(1).with('vgs -o pv_name vg0 2>/dev/null').returns("  PV\n  /dev/pv3\n  /dev/pv2")
+        Facter::Util::Resolution.expects('exec').at_least(1).with('vgs -o pv_name vg-1 2>/dev/null').returns("  PV\n  /dev/pv0")
+        Facter.fact(:lvm_support).expects(:value).at_least(1).returns(true)
+        Facter.value(:lvm_vgs).should == 2
+        Facter.value(:lvm_vg_0).should == 'vg0'
+        Facter.value(:lvm_vg_1).should == 'vg-1'
+        Facter.value(:lvm_vg_vg0_pvs).should == '/dev/pv2,/dev/pv3'
+        Facter.value(:lvm_vg_vg_1_pvs).should == '/dev/pv0'
+      end
     end
   end
 end


### PR DESCRIPTION
It is possible to name a VG something like vg-1, we should
downcase the - if we're going to use it as a name for facter.
