### PR TITLE
Custom variable $vg_name

### DIFF
--- a/manifests/volume_group.pp
+++ b/manifests/volume_group.pp
@@ -4,6 +4,7 @@ define lvm::volume_group (
   $physical_volumes,
   $ensure           = present,
   $logical_volumes  = {},
+  $vg_name          = $name,
 ) {
 
   validate_hash($logical_volumes)
@@ -16,7 +17,7 @@ define lvm::volume_group (
     ensure => $ensure,
   } ->
 
-  volume_group { $name:
+  volume_group { $vg_name:
     ensure           => $ensure,
     physical_volumes => $physical_volumes,
   }
@@ -26,7 +27,7 @@ define lvm::volume_group (
     $logical_volumes,
     {
       ensure       => $ensure,
-      volume_group => $name,
+      volume_group => $vg_name,
     }
   )
 }


### PR DESCRIPTION
Hello,
right now it's not possible to have a name for the volume group different to the `title` of the resource.
When using `hiera_hash` this leads to multiple volume groups when creating the resource since we cannot override the name.
**_Example:**_
_foo1.yaml_

```
lvm_conf:
  'vSystem':
    physical_volumes: '/dev/vda3'
    logical_volumes:
      'root':
        size:                   "20G"
        ensure:                 "present"
        fs_type:                "xfs"
        options:                "noatime,nodiratime"
        mountpath:              "/"
      'home':
        size:                   "5G"
        ensure:                 "present"
        fs_type:                "xfs"
        options:                "noatime,nodiratime"
        mountpath:              "/home"
      'var':
        size:                   "10G"
        ensure:                 "present"
        fs_type:                "xfs"
        options:                "noatime,nodiratime"
        mountpath:              "/var"
```

_foo2.yaml_

```
lvm_conf:
  'System':
    physical_volumes: '/dev/sda2'
    logical_volumes:
      'root':
        size:                   "20G"
        ensure:                 "present"
        fs_type:                "ext4"
        options:                "noatime,nodiratime"
        mountpath:              "/"
      'home':
        size:                   "5G"
        ensure:                 "present"
        fs_type:                "ext4"
        options:                "noatime,nodiratime"
        mountpath:              "/home"
      'var':
        size:                   "10G"
        ensure:                 "present"
        fs_type:                "ext4"
        options:                "noatime,nodiratime"
        mountpath:              "/var"
```

**_Result:**_

```
{"vSystem"=>
  {"physical_volumes"=>"/dev/vda3",
   "logical_volumes"=>
    {"root"=>
      {"size"=>"20G",
       "ensure"=>"present",
       "fs_type"=>"xfs",
       "options"=>"noatime,nodiratime",
       "mountpath"=>"/"},
     "home"=>
      {"size"=>"5G",
       "ensure"=>"present",
       "fs_type"=>"xfs",
       "options"=>"noatime,nodiratime",
       "mountpath"=>"/home"},
     "var"=>
      {"size"=>"10G",
       "ensure"=>"present",
       "fs_type"=>"xfs",
       "options"=>"noatime,nodiratime",
       "mountpath"=>"/var"}}}}
{"System"=>
  {"logical_volumes"=>
    {"root"=>
      {"size"=>"20G",
       "ensure"=>"present",
       "fs_type"=>"ext4",
       "options"=>"noatime,nodiratime",
       "mountpath"=>"/"},
     "home"=>
      {"size"=>"5G",
       "ensure"=>"present",
       "fs_type"=>"ext4",
       "options"=>"noatime,nodiratime",
       "mountpath"=>"/home"},
     "var"=>
      {"size"=>"10G",
       "ensure"=>"present",
       "fs_type"=>"ext4",
       "options"=>"noatime,nodiratime",
       "mountpath"=>"/var"}},
   "physical_volumes"=>"/dev/vda2"},
```

The result is perfectly fine if you want to have multiple VGs on the same node with different names. But having multiple nodes with a single VG and different names for this VGs is not possible.

With this change it will be possible to just us the same resource title and just override the vg names. The old behaviour will still be in place without chaning anything on the current manifests.

Let me know when this change looks ok to you so that I can add some rspec tests and documentation.

Best regards,
mat1010
