### PR TITLE
Set default mount option for dump to 0

### DIFF
--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -7,7 +7,7 @@ define lvm::logical_volume (
   $ensure            = present,
   $options           = 'defaults',
   $pass              = '2',
-  $dump              = '1',
+  $dump              = '0',
   $fs_type           = 'ext4',
   $mkfs_options      = undef,
   $mountpath         = "/${name}",


### PR DESCRIPTION
I would set the default for the dump mount option to 0. I'm not sure about the default with Redhat-based distributions but with Debian/Ubuntu the standard value seems to be 0. Is there a reason for the default value to be 1?
