### PR TITLE
Added the createonly option for the volumegroup and the possibility t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,33 @@ lvm::volume_groups:
         mountpath: /var/backups
         mountpath_require: true
 ```
-
-
+or to just build the VG if it does not exists
+```yaml
+---
+lvm::volume_groups:
+  myvg:
+    createonly: true
+    physical_volumes:
+      /dev/sda2:
+        unless_vg: 'myvg'
+      /dev/sda3:
+        unless_vg: 'myvg'
+    logical_volumes:
+      opt:
+        size: 20G
+      tmp:
+        size: 1G
+      usr:
+        size: 3G
+      var:
+        size: 15G
+      home:
+        size: 5G
+      backup:
+        size: 5G
+        mountpath: /var/backups
+        mountpath_require: true
+```
 
 Except that in the latter case you cannot specify create options.
 If you want to omit the file system type, but still specify the size of the

--- a/manifests/physical_volume.pp
+++ b/manifests/physical_volume.pp
@@ -1,0 +1,19 @@
+# == Define: lvm::physical_volume
+#
+define lvm::physical_volume (
+  $ensure     = present,
+  $force      = false,
+  $unless_vg  = undef,
+) {
+
+  if ($name == undef) {
+    fail("lvm::physical_volume \$name can't be undefined")
+  }
+
+  physical_volume { $name:
+    ensure    => $ensure,
+    force     => $force,
+    unless_vg => $unless_vg
+  }
+
+}

--- a/manifests/volume_group.pp
+++ b/manifests/volume_group.pp
@@ -2,6 +2,7 @@
 #
 define lvm::volume_group (
   $physical_volumes,
+  $createonly       = false,
   $ensure           = present,
   $logical_volumes  = {},
 ) {
@@ -12,12 +13,25 @@ define lvm::volume_group (
     fail("lvm::volume_group \$name can't be undefined")
   }
 
-  physical_volume { $physical_volumes:
-    ensure => $ensure,
-  } ->
+  if is_hash($physical_volumes) {
+    create_resources(
+      'lvm::physical_volume',
+      $physical_volumes,
+      {
+        ensure           => $ensure,
+      }
+    )
+  }
+  else {
+    physical_volume { $physical_volumes:
+      ensure => $ensure,
+    }
+  }
+
 
   volume_group { $name:
     ensure           => $ensure,
+    createonly       => $createonly,
     physical_volumes => $physical_volumes,
   }
 


### PR DESCRIPTION
…o give more information for the PV.

In our infrastructure we have some highlevel configuration in hiera (our global.yaml) that is read via a hiera_hash (with deep merge) by all nodes, this is useful to have all the disk with the same setup.

But we have some exception and so to manage "easily" them we added the option createonly to the define  lvm::volume_group, while working on this we found useful to give more information about the physical volumes as well, so we added a new define and the possibility to use an hash to pass more information to the define lvm::volume_grop. 

Compatibility with the old configuration is mantained, so if physical_volume it's an array nothing change from the past behaviour.

Changed the README to show these changes as well.
