### PR TITLE
Add missing parameters to manage mirrors for lvm::logical_volume.

### DIFF
--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -21,6 +21,11 @@ define lvm::logical_volume (
   $range             = undef,
   $size_is_minsize   = undef,
   $type              = undef,
+  $mirror            = undef,
+  $mirrorlog         = undef,
+  $no_sync           = undef,
+  $region_size       = undef,
+  $alloc             = undef,
 ) {
 
   validate_bool($mountpath_require)
@@ -81,7 +86,12 @@ define lvm::logical_volume (
     extents         => $extents,
     range           => $range,
     size_is_minsize => $size_is_minsize,
-    type            => $type
+    type            => $type,
+    mirror          => $mirror,
+    mirrorlog       => $mirrorlog,
+    no_sync         => $no_sync,
+    region_size     => $region_size,
+    alloc           => $alloc
   }
 
   if $createfs {


### PR DESCRIPTION
Hi,

I think that PR#96 missed to add its new parameters to the define lvm::logical_volumes.

Here is my little PR to fix this.
Thanks.