### PR TITLE
Add mounted parameter to logical volume type

### DIFF
--- a/lib/puppet/type/logical_volume.rb
+++ b/lib/puppet/type/logical_volume.rb
@@ -163,6 +163,9 @@ Puppet::Type.newtype(:logical_volume) do
           end
       end
   end
+  newparam(:mounted) do
+      desc "Specifies if puppet should mount the volume. This only affects what puppet will do, and not what will be mounted at boot-time"
+  end
 
 
   autorequire(:volume_group) do

--- a/spec/unit/type/logical_volume_spec.rb
+++ b/spec/unit/type/logical_volume_spec.rb
@@ -430,4 +430,19 @@ describe Puppet::Type.type(:logical_volume) do
       )
     }.to_not raise_error
   end
+  
+  it 'mounted passed as a parameter does not throw an error' do
+    expect {
+      resource = Puppet::Type.type(:logical_volume).new(
+				{
+        :name             => 'fred',
+        :ensure           => :present,
+        :volume_group     => 'daphne',
+        :size             => '10M',
+        :region_size      => '910',
+        :mounted          => false
+				}
+      )
+    }.to_not raise_error
+  end
 end


### PR DESCRIPTION
Mounted parameter added to logical_volume type. Ticket 3108.

Users should now be able to declare a `mounted` parameter as described in the README, like so:

```
logical_volume {'lv1':
  ensure => present,
  volume_group => 'myvg',
  mounted => true,
  size => '1G',
}
```