### PR TITLE
(MODULES-3230) Add flag to Logical_volume to not resize filesystem

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -188,15 +188,17 @@ Puppet::Type.type(:logical_volume).provide :lvm do
 
             lvextend( '-L', new_size, path) || fail( "Cannot extend to size #{new_size} because lvextend failed." )
 
-            blkid_type = blkid(path)
-            if command(:resize4fs) and blkid_type =~ /\bTYPE=\"(ext4)\"/
-              resize4fs( path) || fail( "Cannot resize file system to size #{new_size} because resize2fs failed." )
-            elsif blkid_type =~ /\bTYPE=\"(ext[34])\"/
-              resize2fs( path) || fail( "Cannot resize file system to size #{new_size} because resize2fs failed." )
-            elsif blkid_type =~ /\bTYPE=\"(xfs)\"/
-              xfs_growfs( path) || fail( "Cannot resize filesystem to size #{new_size} because xfs_growfs failed." )
-            elsif blkid_type =~ /\bTYPE=\"(swap)\"/
-              swapoff( path) && mkswap( path) && swapon( path) || fail( "Cannot resize swap to size #{new_size} because mkswap failed." )
+            unless @resource[:resize_fs] == :false or @resource[:resize_fs] == false or @resource[:resize_fs] == 'false'
+              blkid_type = blkid(path)
+              if command(:resize4fs) and blkid_type =~ /\bTYPE=\"(ext4)\"/
+                resize4fs( path) || fail( "Cannot resize file system to size #{new_size} because resize2fs failed." )
+              elsif blkid_type =~ /\bTYPE=\"(ext[34])\"/
+                resize2fs( path) || fail( "Cannot resize file system to size #{new_size} because resize2fs failed." )
+              elsif blkid_type =~ /\bTYPE=\"(xfs)\"/
+                xfs_growfs( path) || fail( "Cannot resize filesystem to size #{new_size} because xfs_growfs failed." )
+              elsif blkid_type =~ /\bTYPE=\"(swap)\"/
+                swapoff( path) && mkswap( path) && swapon( path) || fail( "Cannot resize swap to size #{new_size} because mkswap failed." )
+              end
             end
 
         end

--- a/lib/puppet/type/logical_volume.rb
+++ b/lib/puppet/type/logical_volume.rb
@@ -135,6 +135,16 @@ Puppet::Type.newtype(:logical_volume) do
     defaultto :false
   end
 
+  newparam(:resize_fs) do
+    desc "Whether or not to resize the underlying filesystem when resizing the logical volume."
+    validate do |value|
+      unless [:true, true, "true", :false, false, "false"].include?(value)
+        raise ArgumentError , "resize_fs must either be true or false"
+      end
+    end
+    defaultto :true
+  end
+
 
   newproperty(:mirror) do
       desc "The number of mirrors of the volume."


### PR DESCRIPTION
Currently changing the size of a logical volume using the lvm provider on our Xen dom0 causes issues for us because the volume is exposed to a vm and is mounted there but the volume does not appear mounted to the host. Therefore, resize2fs tries to do an offline resize on the volume which causes issues. This adds a "resize_fs" flag to the logical_volume type that, when set to false, will not attempt that resize.