### PR TITLE
fixed: executed command 'swapoff' before unmount swap partion.

### DIFF
--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -103,10 +103,10 @@ define lvm::logical_volume (
         }
       } else {
         exec { "swapoff for '${mount_title}'":
-          path      => [ '/bin', '/usr/bin', '/sbin' ],
-          command   => "swapoff ${lvm_device_path}",
-          onlyif    => "grep `readlink -f ${lvm_device_path}` /proc/swaps",
-          subscribe => Mount[$mount_title],
+          path    => [ '/bin', '/usr/bin', '/sbin' ],
+          command => "swapoff ${lvm_device_path}",
+          onlyif  => "grep `readlink -f ${lvm_device_path}` /proc/swaps",
+          notify  => Mount[$mount_title],
         }
       }
     } else {


### PR DESCRIPTION
Bugfix: exec "swapoff for '${mount_title}'" must be applied before unmount swap partition.
Part of puppet report without bugfix:
```
Notice: /Stage[main]/Lvm/Lvm::Volume_group[default]/Lvm::Logical_volume[swap]/Mount[/dev/default/swap]/ensure: undefined 'ensure' from 'unmounted'
Info: Computing checksum on file /etc/fstab
Info: /Stage[main]/Lvm/Lvm::Volume_group[default]/Lvm::Logical_volume[swap]/Mount[/dev/default/swap]: Scheduling refresh of Exec[swapoff for '/dev/default/swap']
Notice: /Stage[main]/Lvm/Lvm::Volume_group[default]/Lvm::Logical_volume[swap]/Filesystem[/dev/default/swap]/ensure: removed
Error: Execution of '/sbin/dmsetup remove default-swap' returned 1: device-mapper: remove ioctl on default-swap failed: Device or resource busy
Command failed
Error: /Stage[main]/Lvm/Lvm::Volume_group[default]/Lvm::Logical_volume[swap]/Logical_volume[swap]/ensure: change from present to absent failed: Execution of '/sbin/dmsetup remove default-swap' returned 1: device-mapper: remove ioctl on default-swap failed: Device or resource busy
Command failed
Notice: /Stage[main]/Lvm/Lvm::Volume_group[default]/Lvm::Logical_volume[swap]/Exec[swapoff for '/dev/default/swap']/returns: executed successfully
Notice: /Stage[main]/Lvm/Lvm::Volume_group[default]/Lvm::Logical_volume[swap]/Exec[swapoff for '/dev/default/swap']: Triggered 'refresh' from 1 events
```
Part of puppet report with bugfix:
```
Info: Applying configuration version '1463668281'
Notice: /Stage[main]/Lvm/Lvm::Volume_group[default]/Lvm::Logical_volume[swap]/Exec[swapoff for '/dev/default/swap']/returns: executed successfully
Info: /Stage[main]/Lvm/Lvm::Volume_group[default]/Lvm::Logical_volume[swap]/Exec[swapoff for '/dev/default/swap']: Scheduling refresh of Mount[/dev/default/swap]
Notice: /Stage[main]/Lvm/Lvm::Volume_group[default]/Lvm::Logical_volume[swap]/Mount[/dev/default/swap]/ensure: undefined 'ensure' from 'unmounted'
Info: Computing checksum on file /etc/fstab
Notice: /Stage[main]/Lvm/Lvm::Volume_group[default]/Lvm::Logical_volume[swap]/Mount[/dev/default/swap]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Lvm/Lvm::Volume_group[default]/Lvm::Logical_volume[swap]/Filesystem[/dev/default/swap]/ensure: removed
Notice: /Stage[main]/Lvm/Lvm::Volume_group[default]/Lvm::Logical_volume[swap]/Logical_volume[swap]/ensure: removed
```