### PR TITLE
fixed charset in provider/logical_volume/lvm.rb

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -98,7 +98,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
         end
 
         if @resource[:persistent]
-            # if persistent param is true, set arg to "y", otherwise set to "n"
+            # if persistent param is true, set arg to "y", otherwise set to "n"
             args.push('--persistent', [:true, true, "true"].include?(@resource[:persistent]) ? 'y' : 'n')
         end
 


### PR DESCRIPTION
Looks like there is a non-ascii-space in the file.

Please merge to avoid errors like

--
Error: invalid byte sequence in US-ASCII
Error: /File[/var/lib/puppet/lib/puppet/provider/logical_volume/lvm.rb]/content: change from {md5}a53348a0ebcbad43c7ad2b0ffd0d2f75 to {md5}95476cfb372e7c165a14c9a126ea9383 failed: invalid byte sequence in US-ASCII
Info: Loading facts
--

Thanks,

 Fabian