### PR TITLE
Add timeout of 30 to execution statements of LVM facts

### DIFF
--- a/lib/facter/lvm_support.rb
+++ b/lib/facter/lvm_support.rb
@@ -1,7 +1,7 @@
 # lvm_support: true/nil
 #   Whether there is LVM support (based on the presence of the "vgs" command)
 Facter.add('lvm_support') do
-  confine :kernel => :linux
+  confine :kernel => :Linux
 
   setcode do
     vgdisplay = Facter::Util::Resolution.which('vgs')
@@ -14,7 +14,7 @@ end
 vg_list = []
 Facter.add('lvm_vgs') do
   confine :lvm_support => true
-  vgs = Facter::Core::Execution.execute('vgs -o name --noheadings 2>/dev/null', options = {:timeout => 30})
+  vgs = Facter::Util::Resolution.exec('vgs -o name --noheadings 2>/dev/null', options = {:timeout => 30})
   if vgs.nil?
     setcode { 0 }
   else

--- a/lib/facter/lvm_support.rb
+++ b/lib/facter/lvm_support.rb
@@ -14,7 +14,7 @@ end
 vg_list = []
 Facter.add('lvm_vgs') do
   confine :lvm_support => true
-  vgs = Facter::Util::Resolution.exec('vgs -o name --noheadings 2>/dev/null')
+  vgs = Facter::Core::Execution.execute('vgs -o name --noheadings 2>/dev/null', options = {:timeout => 30})
   if vgs.nil?
     setcode { 0 }
   else
@@ -29,7 +29,7 @@ vg_list.each_with_index do |vg, i|
   Facter.add("lvm_vg_#{i}") { setcode { vg } }
   Facter.add("lvm_vg_#{vg}_pvs") do
     setcode do
-      pvs = Facter::Util::Resolution.exec("vgs -o pv_name #{vg} 2>/dev/null")
+      pvs = Facter::Core::Execution.execute("vgs -o pv_name #{vg} 2>/dev/null", options = {:timeout => 30})
       res = nil
       unless pvs.nil?
         res = pvs.split("\n").select{|l| l =~ /^\s+\// }.collect(&:strip).sort.join(',')
@@ -44,7 +44,7 @@ end
 pv_list = []
 Facter.add('lvm_pvs') do
   confine :lvm_support => true
-  pvs = Facter::Util::Resolution.exec('pvs -o name --noheadings 2>/dev/null')
+  pvs = Facter::Core::Execution.execute('pvs -o name --noheadings 2>/dev/null', options = {:timeout => 30})
   if pvs.nil?
     setcode { 0 }
   else


### PR DESCRIPTION
This is a followup to here:
https://github.com/puppetlabs/puppetlabs-lvm/pull/98

I figured it was worth putting in a new request versus reopening the old one.  I'd still like to get a timeout on a couple of the facts so that facter will return / doesn't hang on nodes with an underlying disk issue.

There appear to be two versions of valid syntax for the timeout - I used the first but I'm happy to rewrite with the second if preferred.

( [...] ,options = {:timeout => 30})
( [...] ,timeout: 30)

I set the timeout to 30 as a generic value, but I'm happy to adjust.  I still wasn't sure how to pass a value from the Puppet code into the custom fact, but if I can get a pointer on that, I'd be happy to make that change as well.