### PR TITLE
Update fact to add 30 second timeout; refactor due to Windows error

### DIFF
--- a/lib/facter/lvm_support.rb
+++ b/lib/facter/lvm_support.rb
@@ -5,7 +5,7 @@ Facter.add('lvm_support') do
 
   setcode do
     vgdisplay = Facter::Util::Resolution.which('vgs')
-    vgdisplay.nil? ? nil : true
+    vgdisplay.nil? ? nil : nil
   end
 end
 

--- a/lib/facter/lvm_support.rb
+++ b/lib/facter/lvm_support.rb
@@ -1,7 +1,7 @@
 # lvm_support: true/nil
 #   Whether there is LVM support (based on the presence of the "vgs" command)
 Facter.add('lvm_support') do
-  confine :kernel => :linux
+  confine :kernel => :Linux
 
   setcode do
     vgdisplay = Facter::Util::Resolution.which('vgs')
@@ -9,27 +9,43 @@ Facter.add('lvm_support') do
   end
 end
 
+# lvm_vgs: [a-z]+
+#   Array of VG names
+Facter.add('lvm_vg_list') do
+  confine :lvm_support => true
+  setcode do
+    vglist = Facter::Core::Execution.execute('vgs -o name --noheadings --rows 2>/dev/null', options = {:timeout => 30})
+    if vglist.nil?
+      nil
+    else
+      vgs = vglist.split
+      vgs
+    end
+  end
+end
+
+vgs = Facter.value(:lvm_vg_list)
+
 # lvm_vgs: [0-9]+
 #   Number of VGs
-vg_list = []
 Facter.add('lvm_vgs') do
   confine :lvm_support => true
-  vgs = Facter::Util::Resolution.exec('vgs -o name --noheadings 2>/dev/null')
-  if vgs.nil?
-    setcode { 0 }
-  else
-    vg_list = vgs.split
-    setcode { vg_list.length }
+  setcode do
+    if vgs.nil?
+      0
+    else
+      vgs.length
+    end
   end
 end
 
 # lvm_vg_[0-9]+
 #   VG name by index
-vg_list.each_with_index do |vg, i|
+Array(vgs).each_with_index do |vg, i|
   Facter.add("lvm_vg_#{i}") { setcode { vg } }
   Facter.add("lvm_vg_#{vg}_pvs") do
     setcode do
-      pvs = Facter::Util::Resolution.exec("vgs -o pv_name #{vg} 2>/dev/null")
+      pvs = Facter::Core::Execution.execute("vgs -o pv_name #{vg} 2>/dev/null", options = {:timeout => 30})
       res = nil
       unless pvs.nil?
         res = pvs.split("\n").select{|l| l =~ /^\s+\// }.collect(&:strip).sort.join(',')
@@ -39,22 +55,39 @@ vg_list.each_with_index do |vg, i|
   end
 end
 
+# lvm_pv_list: [a-z]+
+#   Array of PV names
+Facter.add('lvm_pv_list') do
+  confine :lvm_support => true
+  setcode do
+    pvlist = Facter::Core::Execution.execute('pvs -o name --noheadings 2>/dev/null', options = {:timeout => 30})
+    if pvlist.nil?
+      []
+    else
+      pv_list = pvlist.strip
+      pv_array = pv_list.split
+      pv_array
+    end
+  end
+end
+
+pvs = Facter.value(:lvm_pv_list)
+
 # lvm_pvs: [0-9]+
 #   Number of PVs
-pv_list = []
 Facter.add('lvm_pvs') do
   confine :lvm_support => true
-  pvs = Facter::Util::Resolution.exec('pvs -o name --noheadings 2>/dev/null')
-  if pvs.nil?
-    setcode { 0 }
-  else
-    pv_list = pvs.split
-    setcode { pv_list.length }
+  setcode do
+    if pvs.nil?
+      0
+    else
+      pvs.length
+    end
   end
 end
 
 # lvm_pv_[0-9]+
 #   PV name by index
-pv_list.each_with_index do |pv, i|
+Array(pvs).each_with_index do |pv, i|
   Facter.add("lvm_pv_#{i}") { setcode { pv } }
 end

--- a/spec/unit/facter/lvm_support_spec.rb
+++ b/spec/unit/facter/lvm_support_spec.rb
@@ -52,20 +52,24 @@ describe 'lvm_vgs facts' do
   context 'when there is lvm support' do
     context 'when there are no vgs' do
       it 'should be set to 0' do
-        Facter::Util::Resolution.stubs('exec') # All other calls
-        Facter::Util::Resolution.expects('exec').at_least(1).with('vgs -o name --noheadings 2>/dev/null').returns(nil)
+        @vgs = nil
+        Facter::Core::Execution.stubs('execute') # All other calls
+        Facter::Core::Execution.expects('execute').at_least(1).with('/sbin/vgs -o name --noheadings --rows 2>/dev/null').returns(nil)
         Facter.fact(:lvm_support).expects(:value).at_least(1).returns(true)
+        Facter.value(:lvm_vg_list).returns(nil)
         Facter.value(:lvm_vgs).should == 0
       end
     end
 
     context 'when there are vgs' do
       it 'should list vgs' do
-        Facter::Util::Resolution.stubs('exec') # All other calls
-        Facter::Util::Resolution.expects('exec').at_least(1).with('vgs -o name --noheadings 2>/dev/null').returns("vg0\nvg1")
-        Facter::Util::Resolution.expects('exec').at_least(1).with('vgs -o pv_name vg0 2>/dev/null').returns("  PV\n  /dev/pv3\n  /dev/pv2")
-        Facter::Util::Resolution.expects('exec').at_least(1).with('vgs -o pv_name vg1 2>/dev/null').returns("  PV\n  /dev/pv0")
+        @vgs = ["vg0","vg1"]
+        Facter::Core::Execution.stubs('execute') # All other calls
+        Facter::Core::Execution.expects('execute').at_least(1).with('/sbin/vgs -o name --noheadings --rows 2>/dev/null').returns("vg0 vg1")
+        Facter::Core::Execution.expects('execute').at_least(1).with('vgs -o pv_name vg0 2>/dev/null').returns("  PV\n  /dev/pv3\n  /dev/pv2")
+        Facter::Core::Execution.expects('execute').at_least(1).with('vgs -o pv_name vg1 2>/dev/null').returns("  PV\n  /dev/pv0")
         Facter.fact(:lvm_support).expects(:value).at_least(1).returns(true)
+        Facter.fact(:lvm_vg_list).returns(["vg0","vg1"])
         Facter.value(:lvm_vgs).should == 2
         Facter.value(:lvm_vg_0).should == 'vg0'
         Facter.value(:lvm_vg_1).should == 'vg1'


### PR DESCRIPTION
The confines started failing for the Windows test node after switching to Facter::Core::Execution.execute to add the timeout.  Rewrote the fact to fix the issues, including adding new array facts for vgs and pvs.