### PR TITLE
Update fact to add 30 second timeout; add ifs to restrict lvm commands

### DIFF
--- a/lib/facter/lvm_support.rb
+++ b/lib/facter/lvm_support.rb
@@ -14,7 +14,11 @@ end
 vg_list = []
 Facter.add('lvm_vgs') do
   confine :lvm_support => true
-  vgs = Facter::Util::Resolution.exec('vgs -o name --noheadings 2>/dev/null')
+
+  lvm = Facter.value(:lvm_support)
+  if lvm 
+    vgs = Facter::Core::Execution.execute('vgs -o name --noheadings 2>/dev/null', timeout: 30)
+  end
   if vgs.nil?
     setcode { 0 }
   else
@@ -29,7 +33,7 @@ vg_list.each_with_index do |vg, i|
   Facter.add("lvm_vg_#{i}") { setcode { vg } }
   Facter.add("lvm_vg_#{vg}_pvs") do
     setcode do
-      pvs = Facter::Util::Resolution.exec("vgs -o pv_name #{vg} 2>/dev/null")
+      pvs = Facter::Core::Execution.execute("vgs -o pv_name #{vg} 2>/dev/null", timeout: 30)
       res = nil
       unless pvs.nil?
         res = pvs.split("\n").select{|l| l =~ /^\s+\// }.collect(&:strip).sort.join(',')
@@ -44,7 +48,11 @@ end
 pv_list = []
 Facter.add('lvm_pvs') do
   confine :lvm_support => true
-  pvs = Facter::Util::Resolution.exec('pvs -o name --noheadings 2>/dev/null')
+
+  lvm = Facter.value(:lvm_support)
+  if lvm 
+    pvs = Facter::Core::Execution.execute('pvs -o name --noheadings 2>/dev/null', timeout: 30)
+  end
   if pvs.nil?
     setcode { 0 }
   else

--- a/spec/unit/facter/lvm_support_spec.rb
+++ b/spec/unit/facter/lvm_support_spec.rb
@@ -52,19 +52,19 @@ describe 'lvm_vgs facts' do
   context 'when there is lvm support' do
     context 'when there are no vgs' do
       it 'should be set to 0' do
-        Facter::Util::Resolution.stubs('exec') # All other calls
-        Facter::Util::Resolution.expects('exec').at_least(1).with('vgs -o name --noheadings 2>/dev/null').returns(nil)
         Facter.fact(:lvm_support).expects(:value).at_least(1).returns(true)
+        Facter::Core::Execution.stubs(:execute) # All other calls
+        Facter::Core::Execution.expects(:execute).at_least(1).with('vgs -o name --noheadings 2>/dev/null', timeout: 30).returns(nil)
         Facter.value(:lvm_vgs).should == 0
       end
     end
 
     context 'when there are vgs' do
       it 'should list vgs' do
-        Facter::Util::Resolution.stubs('exec') # All other calls
-        Facter::Util::Resolution.expects('exec').at_least(1).with('vgs -o name --noheadings 2>/dev/null').returns("vg0\nvg1")
-        Facter::Util::Resolution.expects('exec').at_least(1).with('vgs -o pv_name vg0 2>/dev/null').returns("  PV\n  /dev/pv3\n  /dev/pv2")
-        Facter::Util::Resolution.expects('exec').at_least(1).with('vgs -o pv_name vg1 2>/dev/null').returns("  PV\n  /dev/pv0")
+        Facter::Core::Execution.stubs(:execute) # All other calls
+        Facter::Core::Execution.expects(:execute).at_least(1).with('vgs -o name --noheadings 2>/dev/null', timeout: 30).returns("vg0\nvg1")
+        Facter::Core::Execution.expects(:execute).at_least(1).with('vgs -o pv_name vg0 2>/dev/null', timeout: 30).returns("  PV\n  /dev/pv3\n  /dev/pv2")
+        Facter::Core::Execution.expects(:execute).at_least(1).with('vgs -o pv_name vg1 2>/dev/null', timeout: 30).returns("  PV\n  /dev/pv0")
         Facter.fact(:lvm_support).expects(:value).at_least(1).returns(true)
         Facter.value(:lvm_vgs).should == 2
         Facter.value(:lvm_vg_0).should == 'vg0'
@@ -92,8 +92,8 @@ describe 'lvm_pvs facts' do
   context 'when there is lvm support' do
     context 'when there are no pvs' do
       it 'should be set to 0' do
-        Facter::Util::Resolution.stubs('exec') # All other calls
-        Facter::Util::Resolution.expects('exec').at_least(1).with('pvs -o name --noheadings 2>/dev/null').returns(nil)
+        Facter::Core::Execution.stubs('execute') # All other calls
+        Facter::Core::Execution.expects('execute').at_least(1).with('pvs -o name --noheadings 2>/dev/null', timeout: 30).returns(nil)
         Facter.fact(:lvm_support).expects(:value).at_least(1).returns(true)
         Facter.value(:lvm_pvs).should == 0
       end
@@ -101,8 +101,8 @@ describe 'lvm_pvs facts' do
 
     context 'when there are pvs' do
       it 'should list pvs' do
-        Facter::Util::Resolution.stubs('exec') # All other calls
-        Facter::Util::Resolution.expects('exec').at_least(1).with('pvs -o name --noheadings 2>/dev/null').returns("pv0\npv1")
+        Facter::Core::Execution.stubs('execute') # All other calls
+        Facter::Core::Execution.expects('execute').at_least(1).with('pvs -o name --noheadings 2>/dev/null', timeout: 30).returns("pv0\npv1")
         Facter.fact(:lvm_support).expects(:value).at_least(1).returns(true)
         Facter.value(:lvm_pvs).should == 2
         Facter.value(:lvm_pv_0).should == 'pv0'


### PR DESCRIPTION
This is a followup to here:
#98

I figured it was worth putting in a new request versus reopening the old one. I'd still like to get a timeout on a couple of the facts so that facter will return / doesn't hang on nodes with an underlying disk issue.

There appear to be two versions of valid syntax for the timeout - I used the first but I'm happy to rewrite with the second if preferred.

( [...] ,options = {:timeout => 30})
( [...] ,timeout: 30)

I set the timeout to 30 as a generic value, but I'm happy to adjust. I still wasn't sure how to pass a value from the Puppet code into the custom fact, but if I can get a pointer on that, I'd be happy to make that change as well.

I also added if statements around the lvm commands - because they are not in setcode blocks, the confines listed don't actually apply to them, and with Facter::Core::Execution being used to set the timeout, the error about the missing command now shows up (versus the different way it was handled with Facter::Util::Resolution).

Truthfully, the fact might benefit from being rewritten to be structured (at least add a Facter array for the vg_list and pv_list arrays that are used in the Ruby code) - I started down that path, but my Ruby / rspec isn't the strongest and I figured I'd do a quick patch for now and let someone else tackle a full refactor.
