### PR TITLE
(MODULES-2888) Add thinpool support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,25 @@ lvm::volume { 'mylv':
 }
 ```
 
+Example how to create a thinpool and a thin-provisioned lv:
+
+```puppet
+logical_volume { 'thinpool':
+  ensure       => 'present',
+  thinpool     => true,
+  volume_group => 'vg_system',
+} ->
+
+logical_volume { 'thinlv1':
+  ensure       => 'present',
+  thin         => true,
+  pool         => 'thinpool',
+  volume_group => 'vg_system',
+  size         => '20G',
+}
+
+```
+
 You can also describe your Volume Group like this:
 
 ```puppet
@@ -174,6 +193,9 @@ resources out yourself.
 * stripes (Parameter) - The number of stripes to allocate for the new logical volume.
 * stripesize (Parameter) - The stripesize to use for the new logical volume.
 * volume_group (Parameter) - The volume group name associated with this logical volume. This will automatically set this volume group as a dependency, but it must be defined elsewhere using the volume_group resource type.
+* thinpool (Parameter) - create a thinpool lv
+* thin (Property) - create a thin provisioned lv. requires the pool property
+* pool (Property) - defines the pool to use when creating a thin provisioned lv. Can't be changed after creation.
 
 ### physical_volume
 

--- a/lib/puppet/type/logical_volume.rb
+++ b/lib/puppet/type/logical_volume.rb
@@ -74,6 +74,28 @@ Puppet::Type.newtype(:logical_volume) do
     end
   end
 
+  newparam(:thinpool) do
+    desc "Set to true to make the lv a thinpool"
+    validate do |value|
+      unless [:true, true, "true", :false, false, "false"].include?(value)
+        raise ArgumentError , "thinpool must be either be true or false"
+      end
+    end
+  end
+
+  newparam(:thin) do
+    desc "Set to true to make a thin lv (requires pool)"
+    validate do |value|
+      unless [:true, true, "true", :false, false, "false"].include?(value)
+        raise ArgumentError , "thin must be either be true or false"
+      end
+    end
+  end
+
+  newproperty(:pool) do
+      desc "Pool this lv is linked to"
+  end
+
   newparam(:minor) do
     desc "Set the minor number"
     validate do |value|


### PR DESCRIPTION
Docker on EL (RHEL, CentOS, ...) uses thin provisioned  lv's for
storage. This change adds the thinpool, thin and pool parameters.

Example howto create a thinpool and a thin-provisioned lv:

```

logical_volume { 'thinpool':
  ensure       => 'present',
  thinpool     => true,
  volume_group => 'vg_system',
} ->

logical_volume { 'thinlv1':
  ensure       => 'present',
  thin         => true,
  pool         => 'thinpool',
  volume_group => 'vg_system',
  size         => '20G',
}

```