### PR TITLE
[MODULES-3991] Issue with using /dev/disk/by-path/pci-XXXX:XX:XX.X-scsi-X:X:X:X 

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -77,7 +77,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
             args.push('--stripesize', @resource[:stripesize])
         end
 
-	
+
 
         if @resource[:poolmetadatasize]
             args.push('--poolmetadatasize', @resource[:poolmetadatasize])

--- a/spec/unit/type/filesystem_spec.rb
+++ b/spec/unit/type/filesystem_spec.rb
@@ -5,12 +5,12 @@ describe Puppet::Type.type(:filesystem) do
   it 'raises an ArgumentError when the name is not an absolute path' do
     expect {
       resource = Puppet::Type.type(:filesystem).new(
-				{
-        :name 		=> 'notAnAbsolutePath',
-        :ensure  	=> :present,
-        :fs_type 	=> 'ext3',
-        :options 	=> '-b 4096 -E stride=32,stripe-width=64',
-				}
+        {
+        :name     => 'notAnAbsolutePath',
+        :ensure    => :present,
+        :fs_type   => 'ext3',
+        :options   => '-b 4096 -E stride=32,stripe-width=64',
+        }
       )
     }.to raise_error(Puppet::ResourceError,
                      'Parameter name failed on Filesystem[notAnAbsolutePath]: Filesystem names must be fully qualified')
@@ -19,12 +19,12 @@ describe Puppet::Type.type(:filesystem) do
   it 'does not raise an ArgumentError when the name is an absolute path' do
     expect {
       resource = Puppet::Type.type(:filesystem).new(
-				{
-        :name 		=> '/dev/myvg/mylv',
-        :ensure  	=> :present,
-        :fs_type 	=> 'ext3',
-        :options 	=> '-b 4096 -E stride=32,stripe-width=64',
-				}
+        {
+        :name     => '/dev/myvg/mylv',
+        :ensure    => :present,
+        :fs_type   => 'ext3',
+        :options   => '-b 4096 -E stride=32,stripe-width=64',
+        }
       )
     }.to_not raise_error
   end

--- a/spec/unit/type/logical_volume_spec.rb
+++ b/spec/unit/type/logical_volume_spec.rb
@@ -4,12 +4,12 @@ describe Puppet::Type.type(:logical_volume) do
   it 'raises an ArgumentError when the name has a file separator' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name         => '/dev/lol',
         :ensure       => :present,
         :volume_group => 'myvg',
         :size         => '20G',
-				}
+        }
       )
     }.to raise_error(Puppet::ResourceError,
                      'Parameter name failed on Logical_volume[/dev/lol]: Volume names must be entirely unqualified')
@@ -18,12 +18,12 @@ describe Puppet::Type.type(:logical_volume) do
   it 'does not raise an ArgumentError when the name has no file separator' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name         => 'myvg',
         :ensure       => :present,
         :volume_group => 'myvg',
         :size         => '20G',
-				}
+        }
       )
     }.to_not raise_error
   end
@@ -31,12 +31,12 @@ describe Puppet::Type.type(:logical_volume) do
   it 'invalid logical initial volume size raises error (char)' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name         => 'myvg',
         :ensure       => :present,
         :volume_group => 'myvg',
         :initial_size => 'abcd',
-				}
+        }
       )
     }.to raise_error(Puppet::ResourceError,
                      'Parameter initial_size failed on Logical_volume[myvg]: abcd is not a valid logical volume size')
@@ -45,12 +45,12 @@ describe Puppet::Type.type(:logical_volume) do
   it 'invalid logical initial volume size raises error (suffix)' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name         => 'myvg',
         :ensure       => :present,
         :volume_group => 'myvg',
         :initial_size => '20A',
-				}
+        }
       )
     }.to raise_error(Puppet::ResourceError,
                      'Parameter initial_size failed on Logical_volume[myvg]: 20A is not a valid logical volume size')
@@ -59,12 +59,12 @@ describe Puppet::Type.type(:logical_volume) do
   it 'valid logical volume initial size does not raise error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name         => 'myvg',
         :ensure       => :present,
         :volume_group => 'myvg',
         :initial_size => '20G',
-				}
+        }
       )
     }.to_not raise_error
   end
@@ -72,12 +72,12 @@ describe Puppet::Type.type(:logical_volume) do
   it 'invalid logical volume size raises error (char)' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name         => 'myvg',
         :ensure       => :present,
         :volume_group => 'myvg',
         :size         => 'lucy<3',
-				}
+        }
       )
     }.to raise_error(Puppet::ResourceError,
                      'Parameter size failed on Logical_volume[myvg]: lucy<3 is not a valid logical volume size')
@@ -86,42 +86,42 @@ describe Puppet::Type.type(:logical_volume) do
   it 'invalid logical volume size raises error (suffix)' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name         => 'myvg',
         :ensure       => :present,
         :volume_group => 'myvg',
         :size         => '20Q',
-				}
+        }
       )
     }.to raise_error(Puppet::ResourceError,
                      'Parameter size failed on Logical_volume[myvg]: 20Q is not a valid logical volume size')
   end
 
-  it 'invalid logical volume extent raises error' do 
+  it 'invalid logical volume extent raises error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name         => 'zerocool',
         :ensure       => :present,
         :volume_group => 'myvg',
         :size         => '10M',
         :extents      => 'acidburn',
-				}
+        }
       )
     }.to raise_error(Puppet::ResourceError,
                      'Parameter extents failed on Logical_volume[zerocool]: acidburn is not a valid logical volume extent')
   end
 
-  it 'valid logical volume extent does not raise error' do 
+  it 'valid logical volume extent does not raise error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name         => 'zerocool',
         :ensure       => :present,
         :volume_group => 'myvg',
         :size         => '10M',
         :extents      => '1%vg',
-				}
+        }
       )
     }.to_not raise_error
   end
@@ -129,13 +129,13 @@ describe Puppet::Type.type(:logical_volume) do
   it 'persistent which is not true or false raises error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name         => 'simba',
         :ensure       => :present,
         :volume_group => 'rafiki',
         :size         => '10M',
         :persistent   => 'nala',
-				}
+        }
       )
     }.to raise_error(Puppet::ResourceError,
                      'Parameter persistent failed on Logical_volume[simba]: persistent must be either be true or false')
@@ -144,13 +144,13 @@ describe Puppet::Type.type(:logical_volume) do
   it 'persistent is true does not raise error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name         => 'simba',
         :ensure       => :present,
         :volume_group => 'rafiki',
         :size         => '10M',
         :persistent   => :true,
-				}
+        }
       )
     }.to_not raise_error
   end
@@ -158,13 +158,13 @@ describe Puppet::Type.type(:logical_volume) do
   it 'minor not set to integer between 0 and 255 raises error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name           => 'ringo',
         :ensure         => :present,
         :volume_group   => 'george',
         :size           => '10M',
         :minor          => '910'
-				}
+        }
       )
     }.to raise_error(Puppet::ResourceError,
                      'Parameter minor failed on Logical_volume[ringo]: 910 is not a valid value for minor. It must be an integer between 0 and 255')
@@ -173,13 +173,13 @@ describe Puppet::Type.type(:logical_volume) do
   it 'minor set to integer between 0 and 255 does not raise error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name           => 'ringo',
         :ensure         => :present,
         :volume_group   => 'george',
         :size           => '10M',
         :minor          => '1'
-				}
+        }
       )
     }.to_not raise_error
   end
@@ -187,13 +187,13 @@ describe Puppet::Type.type(:logical_volume) do
   it 'range set outside of valid range raises error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name           => 'john',
         :ensure         => :present,
         :volume_group   => 'paul',
         :size           => '10M',
         :range          => 'pete best'
-				}
+        }
       )
     }.to raise_error(Puppet::ResourceError,
                      'Parameter range failed on Logical_volume[john]: pete best is not a valid range')
@@ -202,13 +202,13 @@ describe Puppet::Type.type(:logical_volume) do
   it 'range set within valid range does not raise error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name           => 'john',
         :ensure         => :present,
         :volume_group   => 'paul',
         :size           => '10M',
         :range          => 'minimum'
-				}
+        }
       )
     }.to_not raise_error
   end
@@ -216,13 +216,13 @@ describe Puppet::Type.type(:logical_volume) do
   it 'invalid number of stripes raises error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name           => 'bert',
         :ensure         => :present,
         :volume_group   => 'ernie',
         :size           => '10M',
         :stripes        => 'rubber duckie'
-				}
+        }
       )
     }.to raise_error(Puppet::ResourceError,
                      'Parameter stripes failed on Logical_volume[bert]: rubber duckie is not a valid stripe count')
@@ -231,13 +231,13 @@ describe Puppet::Type.type(:logical_volume) do
   it 'number of stripes which is a positive integer does not raise error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name           => 'big bird',
         :ensure         => :present,
         :volume_group   => 'elmo',
         :size           => '10M',
         :stripes        => '7'
-				}
+        }
       )
     }.to_not raise_error
   end
@@ -245,13 +245,13 @@ describe Puppet::Type.type(:logical_volume) do
   it 'invalid stripesize raises error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name           => 'bert',
         :ensure         => :present,
         :volume_group   => 'ernie',
         :size           => '10M',
         :stripesize     => 'rubber duckie'
-				}
+        }
       )
     }.to raise_error(Puppet::ResourceError,
                      'Parameter stripesize failed on Logical_volume[bert]: rubber duckie is not a valid stripesize')
@@ -260,13 +260,13 @@ describe Puppet::Type.type(:logical_volume) do
   it 'invalid stripesize raises error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name           => 'bert',
         :ensure         => :present,
         :volume_group   => 'ernie',
         :size           => '10M',
         :stripesize     => '7+'
-				}
+        }
       )
     }.to raise_error(Puppet::ResourceError,
                      'Parameter stripesize failed on Logical_volume[bert]: 7+ is not a valid stripesize')
@@ -275,13 +275,13 @@ describe Puppet::Type.type(:logical_volume) do
   it 'valid stripesize does not raise error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name           => 'big bird',
         :ensure         => :present,
         :volume_group   => 'elmo',
         :size           => '10M',
         :stripesize     => '7'
-				}
+        }
       )
     }.to_not raise_error
   end
@@ -289,13 +289,13 @@ describe Puppet::Type.type(:logical_volume) do
   it 'valid, unstringified stripesize does not raise error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name           => 'big bird',
         :ensure         => :present,
         :volume_group   => 'elmo',
         :size           => '10M',
         :stripesize     => 7
-				}
+        }
       )
     }.to_not raise_error
   end
@@ -303,13 +303,13 @@ describe Puppet::Type.type(:logical_volume) do
   it 'invalid readahead raises error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name           => 'bert',
         :ensure         => :present,
         :volume_group   => 'ernie',
         :size           => '10M',
         :readahead      => 'cookie monster'
-				}
+        }
       )
     }.to raise_error(Puppet::ResourceError,
                      'Parameter readahead failed on Logical_volume[bert]: cookie monster is not a valid readahead count')
@@ -318,13 +318,13 @@ describe Puppet::Type.type(:logical_volume) do
   it 'valid readahead does not raise error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name           => 'bert',
         :ensure         => :present,
         :volume_group   => 'ernie',
         :size           => '10M',
         :readahead      => '7Auto'
-				}
+        }
       )
     }.to_not raise_error
   end
@@ -332,13 +332,13 @@ describe Puppet::Type.type(:logical_volume) do
   it 'size is minsize raises error if not a boolean' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name              => 'kuzco',
         :ensure            => :present,
         :volume_group      => 'kronk',
         :size              => '10M',
         :size_is_minsize   => 'pacha',
-				}
+        }
       )
     }.to raise_error(Puppet::ResourceError,
                      'Parameter size_is_minsize failed on Logical_volume[kuzco]: size_is_minsize must either be true or false')
@@ -347,13 +347,13 @@ describe Puppet::Type.type(:logical_volume) do
   it 'size is minsize does not raise error if boolean' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name             => 'kuzco',
         :ensure           => :present,
         :volume_group     => 'kronk',
         :size             => '10M',
         :size_is_minsize  => 'true'
-				}
+        }
       )
     }.to_not raise_error
   end
@@ -361,13 +361,13 @@ describe Puppet::Type.type(:logical_volume) do
   it 'mirror number outside of 0-4 range throws error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name              => 'scooby doo',
         :ensure            => :present,
         :volume_group      => 'shaggy',
         :size              => '10M',
         :mirror            => '-1'
-				}
+        }
       )
     }.to raise_error(Puppet::ResourceError,
                      'Parameter mirror failed on Logical_volume[scooby doo]: -1 is not a valid number of mirror copies. Use 0 to un-mirror or 1-4 to set up mirroring.')
@@ -376,13 +376,13 @@ describe Puppet::Type.type(:logical_volume) do
   it 'mirror within 0-4 range does not throw error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name              => 'fred',
         :ensure            => :present,
         :volume_group      => 'daphne',
         :size              => '10M',
         :mirror            => '1'
-				}
+        }
       )
     }.to_not raise_error
   end
@@ -390,13 +390,13 @@ describe Puppet::Type.type(:logical_volume) do
   it 'region_size with invalid value throws error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name             => 'fred',
         :ensure           => :present,
         :volume_group     => 'daphne',
         :size             => '10M',
         :region_size      => 'velma'
-				}
+        }
       )
     }.to raise_error(Puppet::ResourceError,
                      'Parameter region_size failed on Logical_volume[fred]: velma is not a valid region size in MB.')
@@ -405,13 +405,13 @@ describe Puppet::Type.type(:logical_volume) do
   it 'region_size with invalid value throws error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name             => 'fred',
         :ensure           => :present,
         :volume_group     => 'daphne',
         :size             => '10M',
         :region_size      => '7+'
-				}
+        }
       )
     }.to raise_error(Puppet::ResourceError,
                      'Parameter region_size failed on Logical_volume[fred]: 7+ is not a valid region size in MB.')
@@ -420,13 +420,13 @@ describe Puppet::Type.type(:logical_volume) do
   it 'region_size set to positive integer does not throw error' do
     expect {
       resource = Puppet::Type.type(:logical_volume).new(
-				{
+        {
         :name             => 'fred',
         :ensure           => :present,
         :volume_group     => 'daphne',
         :size             => '10M',
         :region_size      => '910'
-				}
+        }
       )
     }.to_not raise_error
   end

--- a/spec/unit/type/physical_volume.rb
+++ b/spec/unit/type/physical_volume.rb
@@ -3,10 +3,10 @@ describe Puppet::Type.type(:physical_volume) do
   it 'raises an ArgumentError when the name is not fully qualified' do
     expect {
       resource = Puppet::Type.type(:physical_volume).new(
-				{
+        {
         :name         => 'nope',
         :ensure       => :present,
-				}
+        }
       )
     }.to raise_error(Puppet::ResourceError,
                      'Parameter name failed on Physical_volume[nope]: Physical Volume names must be fully qualified')
@@ -15,10 +15,10 @@ describe Puppet::Type.type(:physical_volume) do
   it 'does not raise an ArgumentError when the name is fully qualified' do
     expect {
       resource = Puppet::Type.type(:physical_volume).new(
-				{
+        {
         :name         => '/dev/lol',
         :ensure       => :present,
-				}
+        }
       )
     }.to_not raise_error
   end
@@ -26,11 +26,11 @@ describe Puppet::Type.type(:physical_volume) do
   it 'raises an ArgumentError when the volume group name is invalid' do
     expect {
       resource = Puppet::Type.type(:physical_volume).new(
-				{
+        {
         :name         => '/dev/myvg',
         :unless_vg    => '!not@valid/group$name',
         :ensure       => :present,
-				}
+        }
       )
     }.to raise_error(Puppet::ResourceError,
                      'Parameter unless_vg failed on Physical_volume[/dev/myvg]: !not@valid/group$name is not a valid volume group name')
@@ -39,11 +39,11 @@ describe Puppet::Type.type(:physical_volume) do
   it 'does not raise an ArgumentError when the volume group name is valid' do
     expect {
       resource = Puppet::Type.type(:physical_volume).new(
-				{
+        {
         :name         => '/dev/myvg',
         :unless_vg    => 'VALIDNAME123',
         :ensure       => :present,
-				}
+        }
       )
     }.to_not raise_error
   end


### PR DESCRIPTION
Attempt to fix https://tickets.puppetlabs.com/browse/MODULES-3991

with the following code in create_vg.pp it physically works but I still get some output that is incorrect.

```
class { 'lvm':
  volume_groups    => {
    'myvg' => {
      physical_volumes => [ '/dev/disk/by-path/pci-0000:00:04.0-virtio-pci-virtio1', ],
      logical_volumes  => {
        'opt' => {
          'size'              => '200M',
          'mountpath'         => '/opt',
        },
      },
    },
  },
}
```

```
[root@localhost ~]# puppet apply create_vg.pp 
Warning: Config file /etc/puppet/hiera.yaml not found, using Hiera defaults
Notice: Compiled catalog for localhost.islab2.lmax in environment production in 0.20 seconds
Notice: /Stage[main]/Lvm/Lvm::Volume_group[myvg]/Volume_group[myvg]/physical_volumes: physical_volumes changed ['/dev/vdb'] to '/dev/disk/by-path/pci-0000:00:04.0-virtio-pci-virtio1'
Notice: Finished catalog run in 0.90 seconds
```
