### PR TITLE
Support Ruby 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,7 @@ matrix:
       env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
     - rvm: 2.1.6
       env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
 notifications:
   email: false


### PR DESCRIPTION
Ruby 2.3.1 is the next ruby version for the Puppet 4 AIO