### PR TITLE
Fix parsing size from lvs output

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -148,7 +148,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
             if $2.to_i == 00
                 return $1 + unit.capitalize
             else
-                return $1 + '.' + $2 + unit.capitalize
+                return $1 + '.' + $2.sub(/0+$/, '') + unit.capitalize
             end
         end
     end

--- a/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
+++ b/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
@@ -27,6 +27,15 @@ describe provider_class do
     end
   end
 
+  describe 'when inspecting' do
+    it "strips zeros from lvs output" do
+      @resource.expects(:[]).with(:name).returns('mylv').at_least_once
+      @resource.expects(:[]).with(:volume_group).returns('myvg').at_least_once
+      @resource.expects(:[]).with(:size).returns('2.5g').at_least_once
+      @provider.expects(:lvs).with('--noheading', '--unit', 'g', '/dev/myvg/mylv').returns(' 2.50g').at_least_once
+      expect(@provider.size).to eq('2.5G')
+    end
+  end
   describe 'when creating' do
     context 'with size' do
       it "should execute 'lvcreate' with a '--size' option" do


### PR DESCRIPTION
lvs prints `2.5G` as `2.50g`. This makes puppet try to extend the lv if you ensure a volume with size of `2.5g`.
`lvextend` complains because of the same size and fails, breaking the puppet apply.

This commit strips zeros from floating point values from lvs ouptut.