### PR TITLE
Added lvm::profile defined resource.

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,32 @@ parameters documented above also apply to AIX systems.
 * range (Parameter) - Sets the inter-physical volume allocation policy. AIX only
 * type (Parameter) - Configures the logical volume type. AIX only
 
+## Defined resource types
+
+### lvm::profile
+
+The `lvm::profile` manages an LVM profile in `/etc/lvm/profile/` and runs the `lvchange` command to make changes.
+
+#### Parameters
+
+* `volume`: Name of the LVM volume this profile is assicuated with
+* `group`: LVM volume group name
+* `filename`: The filename to use, defaults to `<title>.profile`
+* `allocation`: A hash containing the entries for the `allocation` section of the profile
+* `activation`: A hash containing the entries for the `activation` section of the profile
+
+#### Usage example:
+
+```puppet
+lvm::profile { 'docker':
+  volume => 'dockerpool',
+  group  => 'data',
+  activation => {
+    'thin_pool_autoextend_threshold' => '80',
+    'thin_pool_autoextend_percent' => '20',
+  }
+}
+```
 
 ## Limitations
 

--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -1,0 +1,22 @@
+define lvm::profile (
+  $volume,
+  $group,
+  $filename   ="${name}.profile",
+  $allocation = {},
+  $activation = {},
+) {
+
+  file { "/etc/lvm/profile/${filename}":
+    ensure  => file,
+    content => template('lvm/profile.erb'),
+  }
+
+  exec { 'lvm::profile::lvchange':
+    path        => '/sbin:/usr/sbin',
+    command     => "lvchange --profile ${name} ${group}/${volume}",
+    refreshonly => true,
+    subscribe   => File["/etc/lvm/profile/${filename}"],
+  }
+
+}
+

--- a/spec/unit/defines/profile_spec.rb
+++ b/spec/unit/defines/profile_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe 'lvm::profile', :type => :define do
+
+  context "when declared" do
+    let (:title) { 'dockerpool' }
+    let(:params) {{
+      :volume => 'dockerpool',
+      :group  => 'data',
+      :allocation => {
+        'thin_pool_zero' => 1,
+      },
+      :activation => {
+        'thin_pool_autoextend_threshold' => '80',
+        'thin_pool_autoextend_percent'   => '20',
+      }
+    }}
+
+    it do
+      is_expected.to contain_file('/etc/lvm/profile/dockerpool.profile').with(
+        :ensure => :file,
+        :content => "# Managed by Puppet\n#\nallocation {\n  thin_pool_zero=1\n}\nactivation {\n  thin_pool_autoextend_threshold=80\n  thin_pool_autoextend_percent=20\n}\n"
+      )
+    end
+
+    it do
+      is_expected.to contain_exec('lvm::profile::lvchange').with(
+        :command => 'lvchange --profile dockerpool data/dockerpool',
+        :refreshonly => true
+      ).that_subscribes_to('File[/etc/lvm/profile/dockerpool.profile]')
+    end
+
+  end
+end

--- a/templates/profile.erb
+++ b/templates/profile.erb
@@ -1,0 +1,16 @@
+# Managed by Puppet
+#
+<% unless @allocation.empty? -%>
+allocation {
+<% @allocation.each do |key, val| -%>
+  <%= key %>=<%= val %>
+<% end -%>
+}
+<% end -%>
+<% unless @activation.empty? -%>
+activation {
+<% @activation.each do |key, val| -%>
+  <%= key %>=<%= val %>
+<% end -%>
+}
+<% end -%>


### PR DESCRIPTION

This PR adds the ability to manage LVM profiles from the module via a defined type, `lvm::profile`.  And to issue the `lvchange` command when profiles change.

https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Logical_Volume_Manager_Administration/lvm_profiles.html

