### PR TITLE
Cannot add a new volume if the volume group has the same name. Fix: Better regexp for parsing the output of lvs

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -293,7 +293,9 @@ Puppet::Type.type(:logical_volume).provide :lvm do
     private
 
     def lvs_pattern
-        /\s+#{Regexp.quote @resource[:name]}\s+/
+        # lvs output format:
+        # LV      VG       Attr       LSize   Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
+        /\s+#{Regexp.quote @resource[:name]}\s+#{Regexp.quote @resource[:volume_group]}\s+/
     end
 
     def path

--- a/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
+++ b/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
@@ -13,6 +13,7 @@ describe provider_class do
   LV      VG       Attr       LSize   Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
   lv_root VolGroup -wi-ao----  18.54g
   lv_swap VolGroup -wi-ao---- 992.00m
+  data    data     -wi-ao---- 992.00m  
   EOS
 
   describe 'self.instances' do
@@ -24,6 +25,21 @@ describe provider_class do
       logical_volumes = @provider.class.instances.collect {|x| x.name }
 
       expect(logical_volumes).to include('lv_root','lv_swap')
+    end
+  end
+
+  describe 'when checking existence' do
+    it "should return 'true', lv 'data' in vg 'data' exists" do
+      @resource.expects(:[]).with(:name).returns('data')
+      @resource.expects(:[]).with(:volume_group).returns('data').at_least_once
+      @provider.class.stubs(:lvs).with('data').returns(lvs_output)
+      expect(@provider.exists?).to be > 10
+    end
+    it "should return 'nil', lv 'data' in vg 'myvg' does not exist" do
+      @resource.expects(:[]).with(:name).returns('data')
+      @resource.expects(:[]).with(:volume_group).returns('myvg').at_least_once
+      @provider.class.stubs(:lvs).with('myvg').returns(lvs_output)
+      expect(@provider.exists?).to be_nil
     end
   end
 


### PR DESCRIPTION
There is a bug which prevents user from adding a new logical volume if the volume name is the same as the volume group's name.

The regexp which parses the output of lvs command searches only for the name of the new logical volume. If the output contains previously added logical volumes, the regexp will match with the volume group's name of those volumes. Because the logical volume does not actually exist yet, the proceeding function which tries to extract the size of the new volume will fail.

This fix extends the regexp to match not only with the logical volume name put with the combination of logical volume name and the volume group name.


Example output of lvs command:
```
  LV   VG   Attr       LSize Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
  comp data -wi-ao---- 5.00g
  root data -wi-ao---- 5.00g
  swap data -wi-ao---- 4.00g
```

Example of failing conf:
```
---
lvm::volume_groups:
  data:
    physical_volumes:
      - /dev/sda2
      - /dev/sda3
    logical_volumes:
      comp:
        size: 5G   
      data:
        size: 5G
      root:
        size: 5G

```
