### PR TITLE
[#puppethack] fix syntax error in volume.pp

### DIFF
--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -137,7 +137,7 @@ define lvm::volume (
 
     }
     default: {
-      fail ( sprintf("%s%s", 'puppet-lvm::volume: ensure parameter can only ',
+      fail ( sprintf('%s%s', 'puppet-lvm::volume: ensure parameter can only ',
         'be set to cleaned, absent or present') )
     }
   }

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -137,8 +137,8 @@ define lvm::volume (
 
     }
     default: {
-      fail ( 'puppet-lvm::volume: ensure parameter can only be set to ' +
-        'cleaned, absent or present' )
+      fail ( sprintf("%s%s", 'puppet-lvm::volume: ensure parameter can only ',
+        'be set to cleaned, absent or present') )
     }
   }
 }


### PR DESCRIPTION
This commit fixes issue MODULES-4172.
Syntax error (using "+" with string) in fail message of volume.pp.
+ replaced with sprintf for concatanation error string.