### PR TITLE
Fix Error when blkid returns no TYPE field

### DIFF
--- a/lib/puppet/provider/filesystem/lvm.rb
+++ b/lib/puppet/provider/filesystem/lvm.rb
@@ -16,7 +16,8 @@ Puppet::Type.type(:filesystem).provide :lvm do
     end
 
     def fstype
-        /\bTYPE=\"(\S+)\"/.match(blkid(@resource[:name]))[1]
+        fstype_match = /\bTYPE=\"(\S+)\"/.match(blkid(@resource[:name]))
+        if fs_type_match then fstype_match[1] else nil end
     rescue Puppet::ExecutionFailure
         nil
     end


### PR DESCRIPTION
If device has no file system yet, `blkid` return no TYPE information in its output on Ubuntu 16.04. This results is the following error output in Puppet:
```
Debug: Executing: '/sbin/blkid /dev/sdc1'
Error: /Stage[main]/Filesystem[/dev/sdc1]: Could not evaluate: undefined method `[]' for nil:NilClass
```