### PR TITLE
Setting thinpool default to false

### DIFF
--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -21,7 +21,7 @@ define lvm::logical_volume (
   $range             = undef,
   $size_is_minsize   = undef,
   $type              = undef,
-  $thinpool          = undef,
+  $thinpool          = false,
   $poolmetadatasize  = undef,
   $mirror            = undef,
   $mirrorlog         = undef,


### PR DESCRIPTION
According to docs https://github.com/puppetlabs/puppetlabs-lvm/blob/master/README.md, thinpool is default to false, but as we see in https://github.com/puppetlabs/puppetlabs-lvm/blob/master/manifests/logical_volume.pp#L24 it is default to undef and then it is always called in https://github.com/puppetlabs/puppetlabs-lvm/blob/master/manifests/logical_volume.pp#L92