### PR TITLE
Removing the 'extent size' check in logical_volume provider

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -77,7 +77,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
             args.push('--stripesize', @resource[:stripesize])
         end
 
-	
+
 
         if @resource[:poolmetadatasize]
             args.push('--poolmetadatasize', @resource[:poolmetadatasize])
@@ -194,11 +194,6 @@ Puppet::Type.type(:logical_volume).provide :lvm do
                 fail( "Decreasing the size requires manual intervention (#{new_size} < #{current_size})" )
             end
         else
-            ## Check if new size fits the extend blocks
-            if new_size_bytes * lvm_size_units[new_size_unit] % vg_extent_size != 0
-                fail( "Cannot extend to size #{new_size} because VG extent size is #{vg_extent_size} KB" )
-            end
-
             lvextend( '-L', new_size, path) || fail( "Cannot extend to size #{new_size} because lvextend failed." )
 
             unless @resource[:resize_fs] == :false or @resource[:resize_fs] == false or @resource[:resize_fs] == 'false'

--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -62,13 +62,13 @@ define lvm::logical_volume (
   }
 
   if $ensure == 'present' and $createfs {
-    Logical_volume[$name] ->
-    Filesystem[$lvm_device_path] ->
-    Mount[$mount_title]
-  } elsif $ensure != 'present' and $createfs {
-    Mount[$mount_title] ->
-    Filesystem[$lvm_device_path] ->
     Logical_volume[$name]
+    -> Filesystem[$lvm_device_path]
+    -> Mount[$mount_title]
+  } elsif $ensure != 'present' and $createfs {
+    Mount[$mount_title]
+    -> Filesystem[$lvm_device_path]
+    -> Logical_volume[$name]
   }
 
   logical_volume { $name:

--- a/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
+++ b/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
@@ -13,7 +13,7 @@ describe provider_class do
   LV      VG       Attr       LSize   Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
   lv_root VolGroup -wi-ao----  18.54g
   lv_swap VolGroup -wi-ao---- 992.00m
-  data    data     -wi-ao---- 992.00m  
+  data    data     -wi-ao---- 992.00m
   EOS
 
   describe 'self.instances' do
@@ -190,7 +190,7 @@ describe provider_class do
           @provider.create
           @provider.expects(:lvs).with('--noheading', '--unit', 'g', '/dev/myvg/mylv').returns(' 1.00g').at_least_once
           @provider.expects(:lvs).with('--noheading', '-o', 'vg_extent_size', '--units', 'k', '/dev/myvg/mylv').returns(' 1000.00k')
-          proc { @provider.size = '1.15g' }.should raise_error(Puppet::Error, /extent/)
+          proc { @provider.size = '1.15g' }.should raise_error(Puppet::Error)
         end
       end
     end


### PR DESCRIPTION
There are several situations where Puppet will not increase the size of an LV but if you run the equivalent LVM command it will actually work. See [MODULES-4180](https://tickets.puppetlabs.com/browse/MODULES-4180).

Also changes the test to not expect such a specific Puppet error. Finally some minor whitespace and lint fixes.