### PR TITLE
Added Hash as acceptable type for physical_volumes

### DIFF
--- a/manifests/volume_group.pp
+++ b/manifests/volume_group.pp
@@ -1,7 +1,7 @@
 # == Define: lvm::volume_group
 #
 define lvm::volume_group (
-  Variant[Array, String] $physical_volumes,
+  Variant[Hash, Array, String] $physical_volumes,
   Boolean $createonly               = false,
   Enum['present', 'absent'] $ensure = present,
   Hash $logical_volumes             = {},


### PR DESCRIPTION
The line 11 checks if is_hash and that condition can't apply if the only acceptable type are Array and String
The error I got and that is fixed is:
parameter 'physical_volumes' expects a value of type Array or String, got Struct at ...