### PR TITLE
Don't execute the lvm commands when not supported.

### DIFF
--- a/lib/facter/lvm_support.rb
+++ b/lib/facter/lvm_support.rb
@@ -15,7 +15,9 @@ vg_list = []
 Facter.add('lvm_vgs') do
   confine :lvm_support => true
 
-  vgs = Facter::Core::Execution.execute('vgs -o name --noheadings 2>/dev/null', timeout: 30)
+  if Facter.value(:lvm_support)
+    vgs = Facter::Core::Execution.execute('vgs -o name --noheadings 2>/dev/null', timeout: 30)
+  end
   if vgs.nil?
     setcode { 0 }
   else
@@ -46,7 +48,9 @@ pv_list = []
 Facter.add('lvm_pvs') do
   confine :lvm_support => true
 
-  pvs = Facter::Core::Execution.execute('pvs -o name --noheadings 2>/dev/null', timeout: 30)
+  if Facter.value(:lvm_support)
+    pvs = Facter::Core::Execution.execute('pvs -o name --noheadings 2>/dev/null', timeout: 30)
+  end
   if pvs.nil?
     setcode { 0 }
   else


### PR DESCRIPTION
When lvm_support was not present, facter would still attempt to execute the vgs and pvs commands.