### PR TITLE
Add support for resizeing with extents

### DIFF
--- a/lib/puppet/type/logical_volume.rb
+++ b/lib/puppet/type/logical_volume.rb
@@ -58,12 +58,46 @@ Puppet::Type.newtype(:logical_volume) do
     end
   end
 
-  newparam(:extents) do
-    desc "The number of logical extents to allocate for the new logical volume. Set to undef to use all available space"
+  newparam(:resize_extents) do
+    desc "Do resize when setting extents"
+    validate do |value|
+      unless [:true, true, "true", :false, false, "false"].include?(value)
+        raise ArgumentError , "resize_extents must be either be true or false"
+      end
+    end
+    defaultto false
+  end
+
+  newproperty(:extents) do
+    desc "The number of logical extents to allocate for the logical volume."
     validate do |value|
       unless value =~ /^\d+(%(?:vg|pvs|free|origin)?)?$/i
         raise ArgumentError , "#{value} is not a valid logical volume extent"
       end
+    end
+    def insync?(is)
+      unless [:true, true, "true"].include?(@resource[:resize_extents])
+        return true
+      end
+
+      if is =~ /^(\d+(\.\d+)?)(%)?(vg)?$/i
+        current_value = $1.to_f
+        current_percent = !$3.nil?
+        current_type = $4.downcase unless $4.nil?
+      end
+
+      if should =~ /^(\d+)(%)?(vg|pvs|free|origin)?$/i
+        new_value = $1.to_f
+        new_percent = !$2.nil?
+        new_type = $3.downcase unless $3.nil?
+        if not new_type.nil? and ['origin', 'pvs', 'free'].include?(new_type)
+          warn("Warning: #{new_type} is not supported as extents resize, currently set to #{should} and resize_extents set to #{@resource[:resize_extents]}")
+          return true
+        end
+      end
+
+      new_value <= current_value
+
     end
   end
 

--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -28,6 +28,7 @@ define lvm::logical_volume (
   $no_sync           = undef,
   $region_size       = undef,
   $alloc             = undef,
+  $resize_extents    = undef,
 ) {
 
   validate_bool($mountpath_require)
@@ -95,7 +96,8 @@ define lvm::logical_volume (
     mirrorlog        => $mirrorlog,
     no_sync          => $no_sync,
     region_size      => $region_size,
-    alloc            => $alloc
+    alloc            => $alloc,
+    resize_extents   => $resize_extents,
   }
 
   if $createfs {


### PR DESCRIPTION
I have created an option to resize the logical volume by setting the extents. To use this option, the new parameter resize_extents must be set to true.

It cannot be merged with master currently because I have build this change upon version 0.9.0 as this is the latest version currently out. And we use still Puppet 3 (which isn't working anymore on the master). Is it possible to create a 0.9.0 or a Puppet-3 branch?