### PR TITLE
Re-add checks on lvm_support to prevent running lvm commands on e.g. Windows

### DIFF
--- a/lib/facter/lvm_support.rb
+++ b/lib/facter/lvm_support.rb
@@ -15,7 +15,10 @@ vg_list = []
 Facter.add('lvm_vgs') do
   confine :lvm_support => true
 
-  vgs = Facter::Core::Execution.execute('vgs -o name --noheadings 2>/dev/null', timeout: 30)
+  lvm = Facter.value(:lvm_support)
+  if lvm
+    vgs = Facter::Core::Execution.execute('vgs -o name --noheadings 2>/dev/null', timeout: 30)
+  end
   if vgs.nil?
     setcode { 0 }
   else
@@ -46,7 +49,10 @@ pv_list = []
 Facter.add('lvm_pvs') do
   confine :lvm_support => true
 
-  pvs = Facter::Core::Execution.execute('pvs -o name --noheadings 2>/dev/null', timeout: 30)
+  lvm = Facter.value(:lvm_support)
+  if lvm
+    pvs = Facter::Core::Execution.execute('pvs -o name --noheadings 2>/dev/null', timeout: 30)
+  end
   if pvs.nil?
     setcode { 0 }
   else


### PR DESCRIPTION
Commit 41a712913657e66bed41d58972c65f6d38b54d3f caused clients without LVM (e.g. Windows) to execute the LVM commands resulting in errors. This PR reinstates the check on lvm_support.