### PR TITLE
#puppethack Fix error when creating XFS on top of another Filesystem

### DIFF
--- a/lib/puppet/provider/filesystem/lvm.rb
+++ b/lib/puppet/provider/filesystem/lvm.rb
@@ -22,7 +22,7 @@ Puppet::Type.type(:filesystem).provide :lvm do
     end
 
     def mkfs(fs_type, name)
-        mkfs_params = { "reiserfs" => "-q" }
+        mkfs_params = { "reiserfs" => "-q"  , "xfs" => "-f" }
 
         mkfs_cmd = @resource[:mkfs_cmd] != nil ?
                      [@resource[:mkfs_cmd]] :


### PR DESCRIPTION
#puppethack: Related to Ticket https://tickets.puppetlabs.com/browse/MODULES-5504
This is to fix the Lvm generated error when creating xfs on top of existing filesystem (returned 1: mkfs.xfs: /dev/mapper/myvg-mylv appears to contain an existing filesystem (ext4)).
