### PR TITLE
Physical volumes for logical volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ resources out yourself.
 * mounted - If puppet should mount the volume. This only affects what puppet will do, and not what will be mounted at boot-time.
 * no_sync (Parameter) - An optimization in lvcreate, at least on Linux.
 * persistent (Parameter) - Set to true to make the block device persistent
+* physical_volume (Parameter) - Create this logical volume on the specified physical volume
 * poolmetadatasize (Parameter) - Set the initial size of the logical volume pool metadata on creation
 * readahead (Parameter) - The readahead count to use for the new logical volume.
 * region_size (Parameter) - A mirror is divided into regions of this size (in MB), the mirror log uses this granularity to track which regions are in sync. CAN NOT BE CHANGED on already mirrored volume. Take your mirror size in terabytes and round up that number to the next power of 2, using that number as the -R argument.

--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -133,6 +133,10 @@ Puppet::Type.type(:logical_volume).provide :lvm do
         else
             args << @resource[:volume_group]
         end
+
+        if @resource[:physical_volume]
+            args << @resource[:physical_volume]
+        end
         lvcreate(*args)
     end
 

--- a/lib/puppet/type/logical_volume.rb
+++ b/lib/puppet/type/logical_volume.rb
@@ -21,6 +21,10 @@ Puppet::Type.newtype(:logical_volume) do
             volume_group resource type."
   end
 
+  newparam(:physical_volume) do
+    desc "The physical volume name this logical volume will be created on."
+  end
+
   newparam(:initial_size) do
     desc "The initial size of the logical volume. This will only apply to newly-created volumes"
     validate do |value|

--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -28,6 +28,7 @@ define lvm::logical_volume (
   $no_sync                           = undef,
   $region_size                       = undef,
   $alloc                             = undef,
+  $physical_volume                   = undef,
 ) {
 
   $lvm_device_path = "/dev/${volume_group}/${name}"
@@ -90,6 +91,7 @@ define lvm::logical_volume (
     no_sync          => $no_sync,
     region_size      => $region_size,
     alloc            => $alloc,
+    physical_volume  => $physical_volume,
   }
 
   if $createfs {


### PR DESCRIPTION
This change allows the use of `physical_volume` as argument to `logical_volume` so that the new lv will be created on a specific physical volume even if the volume group consists of several physical volumes.

Example:
Volume Group vg00 consists of 4 physical volumes:
```
  PV         VG   Fmt  Attr PSize PFree
  /dev/sda   vg00 lvm2 a--  1.09t    0 
  /dev/sdb   vg00 lvm2 a--  1.09t    0 
  /dev/sdc   vg00 lvm2 a--  1.09t    0 
  /dev/sdd   vg00 lvm2 a--  1.09t    0 
```
Some lvs can span all 4 pvs in a raid1/mirror setup for example:
```
  --- Logical volume ---
  LV Path                /dev/vg00/home
  LV Name                home
  VG Name                vg00
[...]
  Mirrored volumes       4
[...]
  --- Segments ---
  Logical extents 0 to 2559:
    Type                raid1
```
And other volumes can be created on one specific pv of the four that are part of vg00:
```
  --- Logical volume ---
  LV Path                /dev/vg00/data01
  LV Name                data01
  VG Name                vg00
[...]
  --- Segments ---
  Logical extents 0 to 270793:
    Type                linear
    Physical volume     /dev/sda
```

Example hiera code:
```
lvm::volume_groups:
  vg00:
    physical_volumes:
      - '/dev/sda'
      - '/dev/sdb'
      - '/dev/sdc'
      - '/dev/sdd'
    logical_volumes:
      home:
        size: 10GB
        fs_type: xfs
        mirror: 3
        type: raid1
      data01:
        size: ~
        mountpath: '/srv/data01'
        fs_type: xfs
        physical_volume: '/dev/sda'
```