### PR TITLE
Add tasks and `puppet resource` support for logical_volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 .bundle/
 .fixtures/modules
 .fixtures/manifests
+spec/fixtures

--- a/lib/facter/lvm_support.rb
+++ b/lib/facter/lvm_support.rb
@@ -15,9 +15,8 @@ vg_list = []
 Facter.add('lvm_vgs') do
   confine :lvm_support => true
 
-  if Facter.value(:lvm_support)
-    vgs = Facter::Core::Execution.execute('vgs -o name --noheadings 2>/dev/null', timeout: 30)
-  end
+  vgs = Facter::Core::Execution.execute('vgs -o name --noheadings 2>/dev/null', timeout: 30)
+
   if vgs.nil?
     setcode { 0 }
   else
@@ -48,9 +47,8 @@ pv_list = []
 Facter.add('lvm_pvs') do
   confine :lvm_support => true
 
-  if Facter.value(:lvm_support)
-    pvs = Facter::Core::Execution.execute('pvs -o name --noheadings 2>/dev/null', timeout: 30)
-  end
+  pvs = Facter::Core::Execution.execute('pvs -o name --noheadings 2>/dev/null', timeout: 30)
+
   if pvs.nil?
     setcode { 0 }
   else

--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -18,8 +18,6 @@ Puppet::Type.type(:logical_volume).provide :lvm do
     optional_commands :xfs_growfs => 'xfs_growfs',
                       :resize4fs  => 'resize4fs'
 
-    attr_accessor :volume_group
-
     def self.instances
       get_logical_volumes.collect do |logical_volumes_line|
         logical_volumes_properties = get_logical_volume_properties(logical_volumes_line)
@@ -54,6 +52,14 @@ Puppet::Type.type(:logical_volume).provide :lvm do
       logical_volumes_properties[:volume_group] = output_array[1]
 
       logical_volumes_properties
+    end
+
+    # Just assume that the volume group is correct, we don't support changing
+    # it anyway.
+    attr_writer :volume_group
+
+    def volume_group
+        @resource ? @resource[:volume_group] : @volume_group
     end
 
     def create

--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -18,10 +18,15 @@ Puppet::Type.type(:logical_volume).provide :lvm do
     optional_commands :xfs_growfs => 'xfs_growfs',
                       :resize4fs  => 'resize4fs'
 
+    attr_accessor :volume_group
+
     def self.instances
       get_logical_volumes.collect do |logical_volumes_line|
         logical_volumes_properties = get_logical_volume_properties(logical_volumes_line)
-        new(logical_volumes_properties)
+        instance = new(logical_volumes_properties)
+        # Save the volume group in the provider so the type can find it
+        instance.volume_group = logical_volumes_properties[:volume_group]
+        instance
       end
     end
 
@@ -44,9 +49,9 @@ Puppet::Type.type(:logical_volume).provide :lvm do
       output_array = logical_volumes_line.gsub(/\s+/m, ' ').strip.split(" ")
 
       # Assign properties based on headers
-      # Just doing name for now...
-      logical_volumes_properties[:ensure]     = :present
-      logical_volumes_properties[:name]       = output_array[0]
+      logical_volumes_properties[:ensure]       = :present
+      logical_volumes_properties[:name]         = output_array[1]
+      logical_volumes_properties[:volume_group] = output_array[0]
 
       logical_volumes_properties
     end
@@ -146,12 +151,23 @@ Puppet::Type.type(:logical_volume).provide :lvm do
     end
 
     def exists?
-        lvs(@resource[:volume_group]) =~ lvs_pattern
+        begin
+            lvs(@resource[:volume_group]) =~ /#{@resource[:name]}/
+        rescue Puppet::ExecutionFailure
+            # lvs fails if we give it an empty volume group name, as would
+            # happen if we were running `puppet resource`. This should be
+            # interpreted as "The resource does not exist"
+            nil
+        end
     end
 
     def size
         if @resource[:size] =~ /^\d+\.?\d{0,2}([KMGTPE])/i
             unit = $1.downcase
+        else
+            # If we are getting the size initially we don't know what the
+            # units will be, default to GB
+            unit = 'g'
         end
 
         raw = lvs('--noheading', '--unit', unit, path)
@@ -300,9 +316,6 @@ Puppet::Type.type(:logical_volume).provide :lvm do
             end
         end
     end
-
-
-
 
     private
 

--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -50,8 +50,8 @@ Puppet::Type.type(:logical_volume).provide :lvm do
 
       # Assign properties based on headers
       logical_volumes_properties[:ensure]       = :present
-      logical_volumes_properties[:name]         = output_array[1]
-      logical_volumes_properties[:volume_group] = output_array[0]
+      logical_volumes_properties[:name]         = output_array[0]
+      logical_volumes_properties[:volume_group] = output_array[1]
 
       logical_volumes_properties
     end

--- a/lib/puppet/type/logical_volume.rb
+++ b/lib/puppet/type/logical_volume.rb
@@ -13,6 +13,16 @@ Puppet::Type.newtype(:logical_volume) do
         raise ArgumentError, "Volume names must be entirely unqualified"
       end
     end
+
+    # This is a bit of a hack, drags the volume_group up from the provider if
+    # it was specified, allowing `puppet resource` and otrher things that rely
+    # on an indirector search to work
+    munge do |name|
+      if @resource.original_parameters[:provider].respond_to? :volume_group
+        @resource[:volume_group] = @resource.original_parameters[:provider].volume_group
+      end
+      name
+    end
   end
 
   newproperty(:volume_group) do

--- a/lib/puppet/type/logical_volume.rb
+++ b/lib/puppet/type/logical_volume.rb
@@ -15,7 +15,7 @@ Puppet::Type.newtype(:logical_volume) do
     end
   end
 
-  newparam(:volume_group) do
+  newproperty(:volume_group) do
     desc "The volume group name associated with this logical volume.  This will automatically
             set this volume group as a dependency, but it must be defined elsewhere using the
             volume_group resource type."

--- a/spec/unit/classes/lvm_spec.rb
+++ b/spec/unit/classes/lvm_spec.rb
@@ -21,7 +21,7 @@ describe 'lvm', :type => :class do
               'backup' => {
                 'size'              => '5G',
                 'mountpath'         => '/var/backups',
-                'mountpath_require' => true
+                'mountpath_require' => false
               }
             }
           }
@@ -62,7 +62,7 @@ describe 'lvm', :type => :class do
                 'size'              => '5G',
                 'mounted'           => false,
                 'mountpath'         => '/mnt/not_mounted',
-                'mountpath_require' => true
+                'mountpath_require' => false
               }
             }
           }

--- a/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
+++ b/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
@@ -36,9 +36,8 @@ describe provider_class do
       expect(@provider.exists?).to be > 10
     end
     it "should return 'nil', lv 'data' in vg 'myvg' does not exist" do
-      @resource.expects(:[]).with(:name).returns('data')
       @resource.expects(:[]).with(:volume_group).returns('myvg').at_least_once
-      @provider.class.stubs(:lvs).with('myvg').returns(lvs_output)
+      @provider.class.stubs(:lvs).with('myvg').raises(Puppet::ExecutionFailure, 'Execution of \'/sbin/lvs myvg\' returned 5')
       expect(@provider.exists?).to be_nil
     end
   end
@@ -205,6 +204,7 @@ describe provider_class do
             @resource.expects(:[]).with(:volume_group).returns('myvg').at_least_once
             @resource.expects(:[]).with(:size).returns('1g').at_least_once
             @resource.expects(:[]).with(:thinpool).returns('mythinpool').at_least_once
+            @provider.expects(:blkid).with('/dev/myvg/mylv').returns('TYPE=ext4')
             @provider.expects(:lvcreate).with('-n', 'mylv', '--virtualsize', '1g', '--thin', 'myvg/mythinpool')
             @provider.create
             @provider.expects(:lvs).with('--noheading', '--unit', 'g', '/dev/myvg/mylv').returns(' 1.00g').at_least_once

--- a/tasks/ensure_fs.json
+++ b/tasks/ensure_fs.json
@@ -1,0 +1,122 @@
+{
+  "description": "Ensures settings on a filesystem using the type & provider",
+  "input_method": "stdin",
+  "parameters": {
+    "fs_type": {
+      "description": "The file system type. eg. ext3.",
+      "type": "String"
+    },
+    "name": {
+      "description": "Fully qualified name",
+      "type": "String"
+    },
+    "mkfs_cmd": {
+      "description": "Command to use to create the file system. Defaults to mkswap for fs_type=swap, otherwise mkfs.{{fs_type}}",
+      "type": "Optional[String]"
+    },
+    "options": {
+      "description": "Params for the mkfs command. eg. -l internal,agcount=x",
+      "type": "Optional[String]"
+    },
+    "initial_size": {
+      "description": "Initial size of the filesystem, Used only for resource creation, when using this option Puppet will not manage or maintain the size. To resize filesystems see the size property. AIX only.",
+      "type": "Optional[String]"
+    },
+    "size": {
+      "description": "Configures the size of the filesystem.  Supports filesystem resizing.  The size will be rounded up to the nearest multiple of the partition size. AIX only.",
+      "type": "Optional[String]"
+    },
+    "ag_size": {
+      "description": "Specify the allocation group size in megabytes, AIX only.",
+      "type": "Optional[Integer]"
+    },
+    "large_files": {
+      "description": "Large file enabled file system.  AIX only",
+      "type": "Optional[Boolean]"
+    },
+    "compress": {
+      "description": "Data compression, LZ or no. AIX only",
+      "type": "Optional[Enum[LG,no]]"
+    },
+    "frag": {
+      "description": "JFS fragment size in bytes. AIX only",
+      "type": "Optional[Integer]"
+    },
+    "nbpi": {
+      "description": "Bytes per inode. AIX only",
+      "type": "Optional[Integer]"
+    },
+    "logname": {
+      "description": "Configure the log logical volume. AIX only",
+      "type": "Optional[String]"
+    },
+    "logsize": {
+      "description": "Size for an inline log in MB, AIX only",
+      "type": "Optional[Integer]"
+    },
+    "maxext": {
+      "description": "Size of a file extent in file system blocks, AIX only",
+      "type": "Optional[Integer]"
+    },
+    "mountguard": {
+      "description": "Enable the mountguard. AIX only",
+      "type": "Optional[Boolean]"
+    },
+    "agblksize": {
+      "description": "JFS2 block size in bytes, AIX only",
+      "type": "Optional[Integer]"
+    },
+    "extended_attributes": {
+      "description": "Format to be used to store extended attributes. AIX only",
+      "type": "Optional[Enum[v1,v2]]"
+    },
+    "encrypted": {
+      "description": "Specify and encrypted filesystem. AIX only",
+      "type": "Optional[Boolean]"
+    },
+    "isnapshot": {
+      "description": "Specify whether the filesystem supports internal snapshots, AIX only",
+      "type": "Optional[Boolean]"
+    },
+    "mount_options": {
+      "description": "Specify the options to be passed to the mount command. AIX only",
+      "type": "Optional[String]"
+    },
+    "vix": {
+      "description": "Specify that the file system can allocate inode extents smaller than the default, AIX only",
+      "type": "Optional[Boolean]"
+    },
+    "log_partitions": {
+      "description": "Specify the size of the log logical volume as number of logical partitions, AIX only",
+      "type": "Optional[String]"
+    },
+    "nodename": {
+      "description": "Specify the remote host where the filesystem resides. AIX only",
+      "type": "Optional[String]"
+    },
+    "accounting": {
+      "description": "Specify accounting subsystem support, AIX only",
+      "type": "Optional[Boolean]"
+    },
+    "mountgroup": {
+      "description": "Mount group for the filesystem, AIX only",
+      "type": "Optional[String]"
+    },
+    "atboot": {
+      "description": "Specify whether the file system is mounted at boot time, AIX only",
+      "type": "Optional[Boolean]"
+    },
+    "perms": {
+      "description": "Permissions for the filesystem, AIX only",
+      "type": "Optional[Enum[ro,rw]]"
+    },
+    "device": {
+      "description": "Device to create the filesystem on, this can be a device or a logical volume. AIX only",
+      "type": "Optional[String]"
+    },
+    "volume_group": {
+      "description": "Volume group that the file system should be greated on. AIX only.",
+      "type": "Optional[String]"
+    }
+  }
+}

--- a/tasks/ensure_fs.rb
+++ b/tasks/ensure_fs.rb
@@ -1,8 +1,6 @@
 #!/opt/puppetlabs/puppet/bin/ruby
 require 'json'
-require 'yaml'
 require 'puppet'
-require 'pry'
 
 # Parse the parameters
 params = JSON.parse(STDIN.read)

--- a/tasks/ensure_fs.rb
+++ b/tasks/ensure_fs.rb
@@ -1,0 +1,77 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+require 'json'
+require 'yaml'
+require 'puppet'
+require 'pry'
+
+# Parse the parameters
+params = JSON.parse(STDIN.read)
+
+# Load all of Puppet's settings
+Puppet.initialize_settings
+
+# Set Puppet's user to root
+Puppet.settings[:user]  = '0'
+Puppet.settings[:group] = '0'
+
+# Create an empty resource object
+filesystem = Puppet::Resource.new(
+  "Filesystem[#{params['name']}]"
+)
+
+# Prune parameters that we don't need
+filesystem.prune_parameters
+
+# Set the settings we need
+filesystem[:ensure]              = params['ensure']              if params['ensure']
+filesystem[:fs_type]             = params['fs_type']             if params['fs_type']
+filesystem[:name]                = params['name']                if params['name']
+filesystem[:mkfs_cmd]            = params['mkfs_cmd']            if params['mkfs_cmd']
+filesystem[:options]             = params['options']             if params['options']
+filesystem[:initial_size]        = params['initial_size']        if params['initial_size']
+filesystem[:size]                = params['size']                if params['size']
+filesystem[:ag_size]             = params['ag_size']             if params['ag_size']
+filesystem[:large_files]         = params['large_files']         if params['large_files']
+filesystem[:compress]            = params['compress']            if params['compress']
+filesystem[:frag]                = params['frag']                if params['frag']
+filesystem[:nbpi]                = params['nbpi']                if params['nbpi']
+filesystem[:logname]             = params['logname']             if params['logname']
+filesystem[:logsize]             = params['logsize']             if params['logsize']
+filesystem[:maxext]              = params['maxext']              if params['maxext']
+filesystem[:mountguard]          = params['mountguard']          if params['mountguard']
+filesystem[:agblksize]           = params['agblksize']           if params['agblksize']
+filesystem[:extended_attributes] = params['extended_attributes'] if params['extended_attributes']
+filesystem[:encrypted]           = params['encrypted']           if params['encrypted']
+filesystem[:isnapshot]           = params['isnapshot']           if params['isnapshot']
+filesystem[:mount_options]       = params['mount_options']       if params['mount_options']
+filesystem[:vix]                 = params['vix']                 if params['vix']
+filesystem[:log_partitions]      = params['log_partitions']      if params['log_partitions']
+filesystem[:nodename]            = params['nodename']            if params['nodename']
+filesystem[:accounting]          = params['accounting']          if params['accounting']
+filesystem[:mountgroup]          = params['mountgroup']          if params['mountgroup']
+filesystem[:atboot]              = params['atboot']              if params['atboot']
+filesystem[:perms]               = params['perms']               if params['perms']
+filesystem[:device]              = params['device']              if params['device']
+filesystem[:volume_group]        = params['volume_group']        if params['volume_group']
+
+# Save the result
+_resource, report = Puppet::Resource.indirection.save(filesystem)
+
+# Print the logs
+resource_status = report.resource_statuses.values[0]
+
+exit_code = if resource_status.failed
+              1
+            else
+              0
+            end
+
+if resource_status.events.empty?
+  puts 'unchanged'
+else
+  report.logs.each do |log|
+    puts log.to_report
+  end
+end
+
+exit exit_code

--- a/tasks/ensure_lv.json
+++ b/tasks/ensure_lv.json
@@ -1,0 +1,85 @@
+{
+  "description": "Ensures settings on a logical volume using the type & provider",
+  "input_method": "stdin",
+  "parameters": {
+    "ensure": {
+      "description": "Present or absent",
+      "type": "Enum[present,absent]"
+    },
+    "name": {
+      "description": "The name of the logical volume.  This is the unqualified name and will be automatically added to the volume group's device path (e.g., '/dev/$vg/$lv').",
+      "type": "String[1]"
+    },
+    "volume_group": {
+      "description": "The volume group name associated with this logical volume",
+      "type": "Optional[String[1]]"
+    },
+    "size": {
+      "description": "The size of the logical volume. Set to undef to use all available space",
+      "type": "Optional[Pattern[/^[0-9]+(\\.[0-9]+)?[KMGTPEkmgtpe]/]]"
+    },
+    "extents": {
+      "description": "The number of logical extents to allocate for the new logical volume. Set to undef to use all available space",
+      "type": "Optional[Pattern[/^\\d+(%(?:vg|pvs|free|origin)?)?$/]]"
+    },
+    "persistent": {
+      "description": "Set to true to make the block device persistent",
+      "type": "Optional[Boolean]"
+    },
+    "thinpool": {
+      "description": "Set to true to create a thin pool or to pool name to create thin volume",
+      "type": "Optional[Boolean]"
+    },
+    "poolmetadatasize": {
+      "description": "Change the size of logical volume pool metadata",
+      "type": "Optional[Pattern[/^[0-9]+(\\.[0-9]+)?[KMGTPEkmgtpe]/]]"
+    },
+    "minor": {
+      "description": "Set the minor number",
+      "type": "Optional[Integer[0,255]]"
+    },
+    "type": {
+      "description": "Configures the logical volume type",
+      "type": "Optional[String[1]]"
+    },
+    "range": {
+      "description": "Sets the inter-physical volume allocation policy. AIX only",
+      "type": "Optional[Enum[maximum,minimum]]"
+    },
+    "stripes": {
+      "description": "The number of stripes to allocate for the new logical volume",
+      "type": "Optional[Integer]"
+    },
+    "stripesize": {
+      "description": "The stripesize to use for the new logical volume",
+      "type": "Optional[Integer]"
+    },
+    "readahead": {
+      "description": "The readahead count to use for the new logical volume",
+      "type": "Optional[String]"
+    },
+    "resize_fs": {
+      "description": "Whether or not to resize the underlying filesystem when resizing the logical volume",
+      "type": "Optional[Boolean]"
+    },
+    "mirror": {
+      "description": "The number of mirrors of the volume",
+      "type": "Optional[Integer[0,4]]"
+    },
+    "mirrorlog": {
+      "description": "How to store the mirror log",
+      "type": "Optional[Enum[core,disk,mirrored]]"
+    },
+    "alloc": {
+      "description": "Selects the allocation policy when a command needs to allocate Physical Extents from the Volume Group",
+      "type": "Optional[Enum[anywhere,contiguous,cling,inherit,normal]]"
+    },
+    "no_sync": {
+      "description": "An optimization in lvcreate, at least on Linux"
+    },
+    "region_size": {
+      "description": "A mirror is divided into regions of this size (in MB), the mirror log uses this granularity to track which regions are in sync. CAN NOT BE CHANGED on already mirrored volume. Take your mirror size in terabytes and round up that number to the next power of 2, using that number as the -R argument.",
+      "type": "Optional[Integer]"
+    } 
+  }
+}

--- a/tasks/ensure_lv.rb
+++ b/tasks/ensure_lv.rb
@@ -6,8 +6,8 @@ require 'pry'
 
 # Parse the parameters
 # params = JSON.parse(STDIN.read)
-params = JSON.parse(File.read('/home/vagrant/lv_params.json'))
-
+# params = JSON.parse(File.read('/home/vagrant/lv_create.json'))
+params = JSON.parse(File.read('/home/vagrant/lv_delete.json'))
 
 # Load all of Puppet's settings
 Puppet.initialize_settings
@@ -56,14 +56,21 @@ logical_volume[:region_size]      = params['region_size']      if params['region
 # Save the result
 _resource, report = Puppet::Resource.indirection.save(logical_volume)
 
-
-
 # Print the logs
 resource_status = report.resource_statuses.values[0]
-if resource_status.changed
+
+exit_code = if resource_status.failed
+              1
+            else
+              0
+            end
+
+if resource_status.events.empty?
+  puts 'unchanged'
+else
   report.logs.each do |log|
     puts log.to_report
   end
-else
-  puts 'unchanged'
 end
+
+exit exit_code

--- a/tasks/ensure_lv.rb
+++ b/tasks/ensure_lv.rb
@@ -1,0 +1,69 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+require 'json'
+require 'yaml'
+require 'puppet'
+require 'pry'
+
+# Parse the parameters
+# params = JSON.parse(STDIN.read)
+params = JSON.parse(File.read('/home/vagrant/lv_params.json'))
+
+
+# Load all of Puppet's settings
+Puppet.initialize_settings
+
+# Set Puppet's user to root
+Puppet.settings[:user]  = '0'
+Puppet.settings[:group] = '0'
+
+# Go and get the current details of the volume group. This will search for
+# resources on the current system and return them in a native ruby format that
+# we can easily interact with. The "find" method is expectng a string in the
+# following format:
+#    {resource type}/{resource title}
+#
+# This is exactly the same as the parameters you would pass to the
+# `puppet resource` command, except in Ruby.
+logical_volume = Puppet::Resource.indirection.find(
+  "logical_volume/#{params['name']}"
+)
+
+# Prune parameters that we don't need
+logical_volume.prune_parameters
+
+# Set the settings we need
+logical_volume[:ensure]           = params['ensure']           if params['ensure']
+logical_volume[:name]             = params['name']             if params['name']
+logical_volume[:volume_group]     = params['volume_group']     if params['volume_group']
+logical_volume[:size]             = params['size']             if params['size']
+logical_volume[:extents]          = params['extents']          if params['extents']
+logical_volume[:persistent]       = params['persistent']       if params['persistent']
+logical_volume[:thinpool]         = params['thinpool']         if params['thinpool']
+logical_volume[:poolmetadatasize] = params['poolmetadatasize'] if params['poolmetadatasize']
+logical_volume[:minor]            = params['minor']            if params['minor']
+logical_volume[:type]             = params['type']             if params['type']
+logical_volume[:range]            = params['range']            if params['range']
+logical_volume[:stripes]          = params['stripes']          if params['stripes']
+logical_volume[:stripesize]       = params['stripesize']       if params['stripesize']
+logical_volume[:readahead]        = params['readahead']        if params['readahead']
+logical_volume[:resize_fs]        = params['resize_fs']        if params['resize_fs']
+logical_volume[:mirror]           = params['mirror']           if params['mirror']
+logical_volume[:mirrorlog]        = params['mirrorlog']        if params['mirrorlog']
+logical_volume[:alloc]            = params['alloc']            if params['alloc']
+logical_volume[:no_sync]          = params['no_sync']          if params['no_sync']
+logical_volume[:region_size]      = params['region_size']      if params['region_size']
+
+# Save the result
+_resource, report = Puppet::Resource.indirection.save(logical_volume)
+
+
+
+# Print the logs
+resource_status = report.resource_statuses.values[0]
+if resource_status.changed
+  report.logs.each do |log|
+    puts log.to_report
+  end
+else
+  puts 'unchanged'
+end

--- a/tasks/ensure_lv.rb
+++ b/tasks/ensure_lv.rb
@@ -1,13 +1,9 @@
 #!/opt/puppetlabs/puppet/bin/ruby
 require 'json'
-require 'yaml'
 require 'puppet'
-require 'pry'
 
 # Parse the parameters
-# params = JSON.parse(STDIN.read)
-# params = JSON.parse(File.read('/home/vagrant/lv_create.json'))
-params = JSON.parse(File.read('/home/vagrant/lv_delete.json'))
+params = JSON.parse(STDIN.read)
 
 # Load all of Puppet's settings
 Puppet.initialize_settings

--- a/tasks/ensure_pv.json
+++ b/tasks/ensure_pv.json
@@ -1,0 +1,22 @@
+{
+  "description": "Ensures settings on a physical volumes using the type & provider",
+  "input_method": "stdin",
+  "parameters": {
+    "name": {
+      "description": "The name of the physical volume",
+      "type": "String[1]"
+    },
+    "ensure": {
+      "description": "Present or absent",
+      "type": "Enum[present,absent]"
+    },
+    "unless_vg": {
+      "description": "Do not do anything if the VG already exists.  The value should be the name of the volume group to check for.",
+      "type": "Optional[String]"
+    },
+    "force": {
+      "description": "Force the creation without any confirmation",
+      "type": "Optional[Boolean]"
+    }
+  }
+}

--- a/tasks/ensure_pv.rb
+++ b/tasks/ensure_pv.rb
@@ -5,8 +5,7 @@ require 'puppet'
 require 'pry'
 
 # Parse the parameters
-# params = JSON.parse(STDIN.read)
-params = JSON.parse(File.read('/home/vagrant/pv_params.json'))
+params = JSON.parse(STDIN.read)
 
 defaults = {
   'force' => false,
@@ -48,10 +47,19 @@ _resource, report = Puppet::Resource.indirection.save(physical_volume)
 
 # Print the logs
 resource_status = report.resource_statuses.values[0]
-if resource_status.changed
+
+exit_code = if resource_status.failed
+              1
+            else
+              0
+            end
+
+if resource_status.events.empty?
+  puts 'unchanged'
+else
   report.logs.each do |log|
     puts log.to_report
   end
-else
-  puts 'unchanged'
 end
+
+exit exit_code

--- a/tasks/ensure_pv.rb
+++ b/tasks/ensure_pv.rb
@@ -1,0 +1,57 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+require 'json'
+require 'yaml'
+require 'puppet'
+require 'pry'
+
+# Parse the parameters
+# params = JSON.parse(STDIN.read)
+params = JSON.parse(File.read('/home/vagrant/pv_params.json'))
+
+defaults = {
+  'force' => false,
+}
+
+# Merge in the default values
+params = defaults.merge(params)
+
+# Load all of Puppet's settings
+Puppet.initialize_settings
+
+# Set Puppet's user to root
+Puppet.settings[:user]  = '0'
+Puppet.settings[:group] = '0'
+
+# Go and get the current details of the volume group. This will search for
+# resources on the current system and return them in a native ruby format that
+# we can easily interact with. The "find" method is expectng a string in the
+# following format:
+#    {resource type}/{resource title}
+#
+# This is exactly the same as the parameters you would pass to the
+# `puppet resource` command, except in Ruby.
+physical_volume = Puppet::Resource.indirection.find(
+  "physical_volume/#{params['name']}"
+)
+
+# Prune parameters that we don't need
+physical_volume.prune_parameters
+
+# Set the settings we need
+physical_volume[:ensure]    = params['ensure']    if params['ensure']
+physical_volume[:name]      = params['name']      if params['name']
+physical_volume[:unless_vg] = params['unless_vg'] if params['unless_vg']
+physical_volume[:force]     = params['force']     if params['force']
+
+# Save the result
+_resource, report = Puppet::Resource.indirection.save(physical_volume)
+
+# Print the logs
+resource_status = report.resource_statuses.values[0]
+if resource_status.changed
+  report.logs.each do |log|
+    puts log.to_report
+  end
+else
+  puts 'unchanged'
+end

--- a/tasks/ensure_vg.json
+++ b/tasks/ensure_vg.json
@@ -1,0 +1,26 @@
+{
+  "description": "Ensures settings on a volume group using the type & provider",
+  "input_method": "stdin",
+  "parameters": {
+    "name": {
+      "description": "The name of the volume group",
+      "type": "String[1]"
+    },
+    "ensure": {
+      "description": "Present or absent",
+      "type": "Enum[present,absent]"
+    },
+    "createonly": {
+      "description": "If set to true the volume group will be created if it does not exist. If the volume group does exist no action will be taken",
+      "type": "Optional[Boolean]"
+    },
+    "followsymlinks": {
+      "description": "If set to true all current and wanted values of the physical_volumes property will be followed to their real files on disk if they are in fact symlinks. This is useful to have Puppet determine what the actual PV device is if the property value is a symlink, like '/dev/disk/by-path/xxxx -> ../../sda'",
+      "type": "Optional[Boolean]"
+    },
+    "physical_volumes": {
+      "description": "The list of physical volumes to be included in the volume group",
+      "type": "Array[String]"
+    }
+  }
+}

--- a/tasks/ensure_vg.rb
+++ b/tasks/ensure_vg.rb
@@ -5,8 +5,7 @@ require 'puppet'
 require 'pry'
 
 # Parse the parameters
-# params = JSON.parse(STDIN.read)
-params = JSON.parse(File.read('/home/vagrant/vg_params.json'))
+params = JSON.parse(STDIN.read)
 
 # Set parameters to local variables and resolve defaults if required
 name             = params['name']
@@ -49,10 +48,19 @@ _resource, report = Puppet::Resource.indirection.save(volume_group)
 
 # Print the logs
 resource_status = report.resource_statuses.values[0]
-if resource_status.changed
+
+exit_code = if resource_status.failed
+              1
+            else
+              0
+            end
+
+if resource_status.events.empty?
+  puts 'unchanged'
+else
   report.logs.each do |log|
     puts log.to_report
   end
-else
-  puts 'unchanged'
 end
+
+exit exit_code

--- a/tasks/ensure_vg.rb
+++ b/tasks/ensure_vg.rb
@@ -1,0 +1,58 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+require 'json'
+require 'yaml'
+require 'puppet'
+require 'pry'
+
+# Parse the parameters
+# params = JSON.parse(STDIN.read)
+params = JSON.parse(File.read('/home/vagrant/vg_params.json'))
+
+# Set parameters to local variables and resolve defaults if required
+name             = params['name']
+puppet_ensure    = params['ensure']
+createonly       = params['createonly'] || false
+followsymlinks   = params['followsymlinks'] || false
+physical_volumes = params['physical_volumes']
+
+# Load all of Puppet's settings
+Puppet.initialize_settings
+
+# Set Puppet's user to root
+Puppet.settings[:user]  = '0'
+Puppet.settings[:group] = '0'
+
+# Go and get the current details of the volume group. This will search for
+# resources on the current system and return them in a native ruby format that
+# we can easily interact with. The "find" method is expectng a string in the
+# following format:
+#    {resource type}/{resource title}
+#
+# This is exactly the same as the parameters you would pass to the
+# `puppet resource` command, except in Ruby.
+volume_group = Puppet::Resource.indirection.find(
+  "volume_group/#{name}"
+)
+
+# Prune parameters that we don't need
+volume_group.prune_parameters
+
+# Set the settings we need
+volume_group[:name]             = name
+volume_group[:ensure]           = puppet_ensure
+volume_group[:createonly]       = createonly
+volume_group[:followsymlinks]   = followsymlinks
+volume_group[:physical_volumes] = physical_volumes
+
+# Save the result
+_resource, report = Puppet::Resource.indirection.save(volume_group)
+
+# Print the logs
+resource_status = report.resource_statuses.values[0]
+if resource_status.changed
+  report.logs.each do |log|
+    puts log.to_report
+  end
+else
+  puts 'unchanged'
+end

--- a/tasks/extend_lv.json
+++ b/tasks/extend_lv.json
@@ -1,0 +1,18 @@
+{
+  "description": "Extends a logical volume",
+  "input_method": "stdin",
+  "parameters": {
+    "size": {
+      "description": "Intended size or 'full'",
+      "type": "String[1]"
+    },
+    "logical_volume": {
+      "description": "Name of the logical volume to extend",
+      "type": "String[1]"
+    },
+    "volume_group": {
+      "description": "Name of the volume group on which the logical volume resides",
+      "type": "String[1]"
+    }
+  }
+}

--- a/tasks/extend_vg.json
+++ b/tasks/extend_vg.json
@@ -1,0 +1,14 @@
+{
+  "description": "Adds physical volumes to a volume group",
+  "input_method": "stdin",
+  "parameters": {
+    "volume_group": {
+      "description": "The name of the volume group",
+      "type": "String[1]"
+    },
+    "physical_volumes": {
+      "description": "The list of physical volumes to be included in the volume group",
+      "type": "Array[String]"
+    }
+  }
+}

--- a/tasks/extend_vg.rb
+++ b/tasks/extend_vg.rb
@@ -6,10 +6,7 @@ require 'puppet'
 params = JSON.parse(STDIN.read)
 
 # Set parameters to local variables and resolve defaults if required
-name             = params['name']
-puppet_ensure    = params['ensure']
-createonly       = params['createonly'] || false
-followsymlinks   = params['followsymlinks'] || false
+name             = params['volume_group']
 physical_volumes = params['physical_volumes']
 
 # Load all of Puppet's settings
@@ -31,15 +28,15 @@ volume_group = Puppet::Resource.indirection.find(
   "volume_group/#{name}"
 )
 
+throw "Volume group #{name} not found" if volume_group[:ensure] == :absent
+
 # Prune parameters that we don't need
 volume_group.prune_parameters
 
 # Set the settings we need
 volume_group[:name]             = name
-volume_group[:ensure]           = puppet_ensure
-volume_group[:createonly]       = createonly
-volume_group[:followsymlinks]   = followsymlinks
-volume_group[:physical_volumes] = physical_volumes
+volume_group[:physical_volumes] << physical_volumes
+volume_group[:physical_volumes].flatten!
 
 # Save the result
 _resource, report = Puppet::Resource.indirection.save(volume_group)

--- a/tasks/mount_lv.json
+++ b/tasks/mount_lv.json
@@ -1,0 +1,42 @@
+{
+  "description": "Mounts a logical volume",
+  "input_method": "stdin",
+  "parameters": {
+    "volume_group": {
+      "description": "The name of the volume group",
+      "type": "String[1]"
+    },
+    "logical_volume": {
+      "description": "The name of the logical_volume to mount",
+      "type": "String[1]"
+    },
+    "mountpoint": {
+      "description": "Where to mount the logical volume",
+      "type": "String[1]"
+    },
+    "fstype": {
+      "description": "The mount type. Valid values depend on the operating system. This is a required option.",
+      "type": "String"
+    },
+    "options": {
+      "description": "A single string containing options for the mount, as they would appear in fstab on Linux. For many platforms this is a comma-delimited string",
+      "type": "Optional[String]"
+    },
+    "atboot": {
+      "description": "Whether to mount the mount at boot. Not all platforms support this.",
+      "type": "Optional[Boolean]"
+    },
+    "owner": {
+      "description": "Owner for the mountpoint",
+      "type": "Optional[String]"
+    },
+    "group": {
+      "description": "Group for the mountpoint",
+      "type": "Optional[String]"
+    },
+    "mode": {
+      "description": "Permissions for the mountpoint",
+      "type": "Optional[String]"
+    }
+  }
+}

--- a/tasks/mount_lv.rb
+++ b/tasks/mount_lv.rb
@@ -1,0 +1,96 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+require 'json'
+require 'puppet'
+
+# Parse the parameters
+# params = JSON.parse(STDIN.read)
+params = JSON.parse(File.read('/home/vagrant/mount_lv.json'))
+
+# Set parameters to local variables and resolve defaults if required
+volume_group   = params['volume_group']
+logical_volume = params['logical_volume']
+mountpoint     = params['mountpoint']
+options        = params['options']
+atboot         = params['atboot']
+fstype         = params['fstype']
+owner          = params['owner']
+group          = params['group']
+mode           = params['mode']
+
+# Check if we are managing any permissions
+permissions_set = !(owner.nil? and group.nil? and mode.nil?)
+
+# Load all of Puppet's settings
+Puppet.initialize_settings
+
+# Set Puppet's user to root
+Puppet.settings[:user]  = '0'
+Puppet.settings[:group] = '0'
+
+# Go and get the current details of the volume group. This will search for
+# resources on the current system and return them in a native ruby format that
+# we can easily interact with. The "find" method is expectng a string in the
+# following format:
+#    {resource type}/{resource title}
+#
+# This is exactly the same as the parameters you would pass to the
+# `puppet resource` command, except in Ruby.
+
+# Create the directory for the mountpoint
+`mkdir -p #{mountpoint}`
+
+if permissions_set
+  # Set permissions
+  mount_file_resource = Puppet::Resource.new(
+    "File[#{mountpoint}]"
+  )
+
+  mount_file_resource[:ensure] = :directory
+  mount_file_resource[:owner]  = owner if owner
+  mount_file_resource[:group]  = group if group
+  mount_file_resource[:mode]   = mode if mode
+
+  # Execute the permissions change
+  _resource, report = Puppet::Resource.indirection.save(mount_file_resource)
+
+  # If it fails, print the error and exit
+  if report.resource_statuses.values[0].failed
+    report.logs.each do |log|
+      puts log.to_report
+    end
+    exit 1
+  end
+end
+
+# Mount the logical volume
+mount_resource = Puppet::Resource.new(
+  "Mount[#{mountpoint}]"
+)
+
+mount_resource[:ensure]  = 'mounted'
+mount_resource[:options] = options if options
+mount_resource[:atboot]  = atboot if atboot
+mount_resource[:fstype]  = fstype if fstype
+mount_resource[:device]  = "/dev/#{volume_group}/#{logical_volume}"
+
+# Save the result
+_resource, report = Puppet::Resource.indirection.save(mount_resource)
+
+# Print the logs
+resource_status = report.resource_statuses.values[0]
+
+exit_code = if resource_status.failed
+              1
+            else
+              0
+            end
+
+if resource_status.events.empty?
+  puts 'unchanged'
+else
+  report.logs.each do |log|
+    puts log.to_report
+  end
+end
+
+exit exit_code


### PR DESCRIPTION
The PR adds the following functionality:

  - `puppet resource logical_volume` now works
  - Tests now pass
  - Adds tasks for common LVM operations

I wrote the tasks in ruby so as to take advantage of the types and providers and to avoid duplicating logic. New features and bugfixes in the types and providers should automatically apply to the tasks too. The disadvantage of this approach is that the tasks will not work unless run on a machine that has both Puppet installed and the `lvm` module on it (likely via pluginsync). This means they will not be useful for most bolt users, sorry bolt users.