### PR TITLE
volume_group type does not handle passing of physical_volumes as a hash

### DIFF
--- a/lib/puppet/type/volume_group.rb
+++ b/lib/puppet/type/volume_group.rb
@@ -11,6 +11,14 @@ Puppet::Type.newtype(:volume_group) do
              will automatically set these as dependencies, but they must be defined elsewhere
              using the physical_volume resource type."
 
+        munge do |value|
+          if value.is_a?(Hash) then
+            value.keys.sort
+          else
+            value
+          end
+        end
+
         def insync?(is)
           if @resource.parameter(:followsymlinks).value == :true then
             real_should = []


### PR DESCRIPTION
The documentation (README) indicates that we can do this:

```
class { 'lvm':
  volume_groups => {
    'vg' => {
      createonly => true,
      physical_volumes => {
        '/dev/sdb' => {
          unless_vg => 'vg',
        },
      },
    },
  },
}
```
However, this results in a message like so:
```
2018-11-08 12:23:02 +0000 Puppet (err): Execution of '/sbin/vgcreate vg {"/dev/sdb"=>{"unless_vg"=>"vg"}}' returned 5: Device {"/dev/sdb"=>{"unless_vg"=>"vg"}} not found.
2018-11-08 12:23:02 +0000 /Stage[main]/Lvm/Lvm::Volume_group[vg]/Volume_group[vg]/ensure (err): change from 'absent' to 'present' failed: Execution of '/sbin/vgcreate vg {"/dev/sdb"=>{"unless_vg"=>"vg"}}' returned 5: Device {"/dev/sdb"=>{"unless_vg"=>"vg"}} not found.
```

The issue is that although the defines permit the passing of physical_volumes as a hash, the type/provider does not.

This pull request attempts to fix that.