### PR TITLE
Allow puppetlabs-stdlib versions >= 5.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     }
   ],
   "data_provider": null,


### PR DESCRIPTION
This commit bumps the upper boundary of the stdlib dependency.

It should help avoid conflicts (librarian-puppet) such as:

```
[Librarian]   Module puppetlabs-lvm found versions: 1.1.0, 1.0.1, 1.0.0, 0.9.0, 0.8.0, 0.7.0, 0.6.0, 0.5.0, 0.4.0, 0.3.3, 0.3.2, 0.3.1, 0.3.0, 0.2.0, 0.1.2, 0.1.1, 0.1.0, 0.0.1
[Librarian]     Checking puppetlabs-lvm/1.1.0 <https://forgeapi.puppetlabs.com>
[Librarian]       Resolved puppetlabs-lvm (< 2.0.0, >= 1.0.0) <https://forgeapi.puppetlabs.com> at puppetlabs-lvm/1.1.0 <https://forgeapi.puppetlabs.com>
[Librarian]   Resolved puppetlabs-lvm (< 2.0.0, >= 1.0.0) <https://forgeapi.puppetlabs.com>
[Librarian] Conflict between puppetlabs-stdlib (< 5.0.0, >= 4.13.1) <(no source specified)> and puppetlabs-stdlib/5.1.0 <https://forgeapi.puppetlabs.com>
```

We need to use stdlib >= 5.1 for compatibility with puppet 6.