### PR TITLE
(maint) - Fix rubygems-update for ruby < 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ language: ruby
 bundler_args: '--without development system_tests'
 
 before_install:
-  - 'gem update --system'
+  - 'gem update --system $RUBYGEMS_VERSION'
   - 'gem update bundler'
 
 script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'
@@ -17,7 +17,7 @@ matrix:
   fast_finish: true
   include:
     - rvm: 2.1.6
-      env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
+      env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes" RUBYGEMS_VERSION=2.7.8
     - rvm: 2.3.1
       env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
 


### PR DESCRIPTION
Update to travis file to account for issues that have arisen with the highest rubygem version below 2.3.0