### PR TITLE
Managing unmanaged file resource

### DIFF
--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -34,8 +34,8 @@ define lvm::logical_volume (
 
   if $mountpath_require and $fs_type != 'swap' {
     file { $mountpath:
-      ensure  => directory,
-      before  => Mount[$mountpath],
+      ensure => directory,
+      before => Mount[$mountpath],
     }
 
     Mount {

--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -33,6 +33,11 @@ define lvm::logical_volume (
   $lvm_device_path = "/dev/${volume_group}/${name}"
 
   if $mountpath_require and $fs_type != 'swap' {
+    file { $mountpath:
+      ensure  => directory,
+      before  => Mount[$mountpath],
+    }
+
     Mount {
       require => File[$mountpath],
     }


### PR DESCRIPTION
The Mount resource default statement is dependent on a resource not managed by the module so it bombs out; the exec statement at the bottom of logical_volume doesn't consistently execute on puppetserver 4.10 for some reason.