### PR TITLE
Fix false positive detection of prefixed lvs

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -157,7 +157,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
   end
 
   def exists?
-    lvs(@resource[:volume_group]) =~ %r{#{@resource[:name]}}
+    lvs(@resource[:volume_group]) =~ lvs_pattern
   rescue Puppet::ExecutionFailure
     # lvs fails if we give it an empty volume group name, as would
     # happen if we were running `puppet resource`. This should be

--- a/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
+++ b/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
@@ -34,6 +34,12 @@ describe provider_class do
       @provider.class.stubs(:lvs).with('data').returns(lvs_output)
       expect(@provider.exists?).to be > 10
     end
+    it "returns 'nil', lv 'swap' in vg 'VolGroup' exists" do
+      @resource.expects(:[]).with(:name).returns('swap')
+      @resource.expects(:[]).with(:volume_group).returns('VolGroup').at_least_once
+      @provider.class.stubs(:lvs).with('VolGroup').returns(lvs_output)
+      expect(@provider.exists?).to be_nil
+    end
     it "returns 'nil', lv 'data' in vg 'myvg' does not exist" do
       @resource.expects(:[]).with(:volume_group).returns('myvg').at_least_once
       @provider.class.stubs(:lvs).with('myvg').raises(Puppet::ExecutionFailure, 'Execution of \'/sbin/lvs myvg\' returned 5')


### PR DESCRIPTION
If a logical volume with the name prefixlvname is created before the logical volume with name lvname then lvname is never created because exists? returns true for it. See also #231.