### PR TITLE
 Fix false positive detection of prefixed lvs

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -157,7 +157,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
   end
 
   def exists?
-    lvs(@resource[:volume_group]) =~ %r{#{@resource[:name]}}
+    lvs(@resource[:volume_group]) =~ %r{\s+#{Regexp.quote @resource[:name]}\s+}
   rescue Puppet::ExecutionFailure
     # lvs fails if we give it an empty volume group name, as would
     # happen if we were running `puppet resource`. This should be


### PR DESCRIPTION
If a logical volume with the name prefixlvname is created before the logical volume with name lvname then lvname is never created because exists? returns true for it. See also #230.