### PR TITLE
Revert "volume_group type does not handle passing of physical_volumes as a hash"

### DIFF
--- a/lib/puppet/type/volume_group.rb
+++ b/lib/puppet/type/volume_group.rb
@@ -11,14 +11,6 @@ Puppet::Type.newtype(:volume_group) do
              will automatically set these as dependencies, but they must be defined elsewhere
              using the physical_volume resource type."
 
-        munge do |value|
-          if value.is_a?(Hash) then
-            value.keys.sort
-          else
-            value
-          end
-        end
-
         def insync?(is)
           if @resource.parameter(:followsymlinks).value == :true then
             real_should = []


### PR DESCRIPTION
Reverts puppetlabs/puppetlabs-lvm#219