### PR TITLE
RFC: Not all LVM versions support flags used in facts

### DIFF
--- a/lib/facter/logical_volumes.rb
+++ b/lib/facter/logical_volumes.rb
@@ -15,16 +15,14 @@ Facter.add(:logical_volumes) do
     columns = [
       'lv_uuid',
       'lv_name',
-      'lv_full_name',
       'lv_path',
-      'lv_dm_path',
       'lv_attr',
-      'lv_layout',
-      'lv_role',
-      'lv_active',
       'lv_size',
-      'lv_permissions',
     ]
+    lvm_version = Gem::Version.new(Facter.value(:lvm_version))
+    columns.push('lv_active') if lvm_version >= Gem::Version.new('2.02.99')
+    columns.push('lv_full_name', 'lv_dm_path', 'lv_permissions') if lvm_version >= Gem::Version.new('2.02.108')
+    columns.push('lv_layout', 'lv_role') if lvm_version >= Gem::Version.new('2.02.110')
 
     output = Facter::Core::Execution.exec("lvs -o #{columns.join(',')}  --noheading --nosuffix")
     Puppet_X::LVM::Output.parse('lv_name', columns, output)

--- a/lib/facter/logical_volumes.rb
+++ b/lib/facter/logical_volumes.rb
@@ -20,6 +20,7 @@ Facter.add(:logical_volumes) do
       'lv_size',
     ]
     lvm_version = Gem::Version.new(Facter.value(:lvm_version))
+    columns.push('lv_path') if lvm_version >= Gem::Version.new('2.02.68')
     columns.push('lv_active') if lvm_version >= Gem::Version.new('2.02.99')
     columns.push('lv_full_name', 'lv_dm_path', 'lv_permissions') if lvm_version >= Gem::Version.new('2.02.108')
     columns.push('lv_layout', 'lv_role') if lvm_version >= Gem::Version.new('2.02.110')

--- a/lib/facter/lvm_support.rb
+++ b/lib/facter/lvm_support.rb
@@ -9,6 +9,17 @@ Facter.add('lvm_support') do
   end
 end
 
+Facter.add('lvm_version') do
+  confine :lvm_support => true
+  if Facter.value(:lvm_support)
+    lvm_version = Facter::Core::Execution.execute('vgs --version 2> /dev/null', timeout: 30)
+    unless lvm_version.nil?
+      lvm_version = lvm_version.split("\n").select{|l| l =~ /LVM version/}.first[/version:\s+(\d+\.\d+.\d+)/, 1]
+      setcode { lvm_version }
+    end
+  end
+end
+
 # lvm_vgs: [0-9]+
 #   Number of VGs
 vg_list = []
@@ -18,7 +29,7 @@ Facter.add('lvm_vgs') do
   if Facter.value(:lvm_support)
     vgs = Facter::Core::Execution.execute('vgs -o name --noheadings 2>/dev/null', timeout: 30)
   end
-  
+
   if vgs.nil?
     setcode { 0 }
   else

--- a/lib/facter/physical_volumes.rb
+++ b/lib/facter/physical_volumes.rb
@@ -25,9 +25,9 @@ Facter.add(:physical_volumes) do
       'pv_pe_alloc_count',
       'pv_mda_count',
       'pv_mda_used_count',
-      'pv_ba_start',
-      'pv_ba_size',
     ]
+    lvm_version = Gem::Version.new(Facter.value(:lvm_version))
+    columns.push('pv_ba_start', 'pv_ba_size') if lvm_version >= Gem::Version.new('2.02.99')
 
     output = Facter::Core::Execution.exec("pvs -o #{columns.join(',')}  --noheading --nosuffix")
     Puppet_X::LVM::Output.parse('pv_name', columns, output)

--- a/lib/facter/physical_volumes.rb
+++ b/lib/facter/physical_volumes.rb
@@ -24,9 +24,9 @@ Facter.add(:physical_volumes) do
       'pv_pe_count',
       'pv_pe_alloc_count',
       'pv_mda_count',
-      'pv_mda_used_count',
     ]
     lvm_version = Gem::Version.new(Facter.value(:lvm_version))
+    columns.push('pv_mda_used_count') if lvm_version >= Gem::Version.new('2.02.69')
     columns.push('pv_ba_start', 'pv_ba_size') if lvm_version >= Gem::Version.new('2.02.99')
 
     output = Facter::Core::Execution.exec("pvs -o #{columns.join(',')}  --noheading --nosuffix")

--- a/lib/facter/volume_groups.rb
+++ b/lib/facter/volume_groups.rb
@@ -16,11 +16,11 @@ Facter.add(:volume_groups) do
       'vg_uuid',
       'vg_name',
       'vg_attr',
-      'vg_permissions',
-      'vg_allocation_policy',
       'vg_size',
       'vg_free',
     ]
+    lvm_version = Gem::Version.new(Facter.value(:lvm_version))
+    columns.push('vg_permissions', 'vg_allocation_policy') if lvm_version >= Gem::Version.new('2.02.108')
 
     output = Facter::Core::Execution.exec("vgs -o #{columns.join(',')}  --noheading --nosuffix")
     Puppet_X::LVM::Output.parse('vg_name', columns, output)


### PR DESCRIPTION
Hello all,

I created [MODULES-9779](https://tickets.puppetlabs.com/browse/) which describes how certains flags used in facts aren't supported with older versions of lvm2 (namely on RHEL 5.11).

For instance, the following flags don't exist in RHEL 5 / lvm2-2.02.88:
- lv_full_name
- lv_dm_path
- lv_layout
- lv_role
- lv_active
- lv_permissions

They respectively appear in:
- lv_full_name: appears in v2_02_108
- lv_dm_path: appears in v2_02_108
- lv_layout: appears in v2_02_110
- lv_role: appears in v2_02_110
- lv_active: appears in v2_02_99
- lv_permissions: appears in v2_02_108

I created the following commit where I create a new fact lvm_version which is the version of lvm2. Based on it, I add supported flags before querying lvm for logical_volumes, physical_volumes and volume_groups.

I'd like to hear your comments about it? Is that the way to do it? As in get the version and work on that? And so on...

Cheers,
Mathieu
