### PR TITLE
correctly match lv name in lvs output

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -157,7 +157,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
   end
 
   def exists?
-    lvs(@resource[:volume_group]) =~ %r{#{@resource[:name]}}
+    lvs(@resource[:volume_group]) =~ %r{^\s*#{@resource[:name]}\s}
   rescue Puppet::ExecutionFailure
     # lvs fails if we give it an empty volume group name, as would
     # happen if we were running `puppet resource`. This should be


### PR DESCRIPTION
The lv name is the first element in the table, so we should match only on that.
The inexact match resulted in `exists?` returning `true` when the lv name matches part of either the vg name or part of another lv name