### PR TITLE
Make lv that is a substring of a vg work

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -157,7 +157,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
   end
 
   def exists?
-    lvs(@resource[:volume_group]) =~ %r{#{@resource[:name]}}
+    lvs(@resource[:volume_group]) =~ lvs_pattern
   rescue Puppet::ExecutionFailure
     # lvs fails if we give it an empty volume group name, as would
     # happen if we were running `puppet resource`. This should be

--- a/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
+++ b/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
@@ -9,10 +9,11 @@ describe provider_class do
   end
 
   lvs_output = <<-EOS
-  LV      VG       Attr       LSize   Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
-  lv_root VolGroup -wi-ao----  18.54g
-  lv_swap VolGroup -wi-ao---- 992.00m
-  data    data     -wi-ao---- 992.00m
+  LV      VG         Attr       LSize   Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
+  lv_root VolGroup   -wi-ao----  18.54g
+  lv_swap VolGroup   -wi-ao---- 992.00m
+  data    data       -wi-ao---- 992.00m
+  j1      vg_jenkins -wi-a-----   1.00g
   EOS
 
   describe 'self.instances' do
@@ -33,6 +34,12 @@ describe provider_class do
       @resource.expects(:[]).with(:volume_group).returns('data').at_least_once
       @provider.class.stubs(:lvs).with('data').returns(lvs_output)
       expect(@provider.exists?).to be > 10
+    end
+    it "returns 'nil', lv 'jenkins' in vg 'vg_jenkins' exists" do
+      @resource.expects(:[]).with(:name).returns('jenkins')
+      @resource.expects(:[]).with(:volume_group).returns('vg_jenkins').at_least_once
+      @provider.class.stubs(:lvs).with('vg_jenkins').returns(lvs_output)
+      expect(@provider.exists?).to be_nil
     end
     it "returns 'nil', lv 'data' in vg 'myvg' does not exist" do
       @resource.expects(:[]).with(:volume_group).returns('myvg').at_least_once


### PR DESCRIPTION
This PR builds on #230. In local testing all tests related to this PR pass while some facter-related tests failed on this branch and on master.

Prior to this commit a logical volume that was a substring of the name of a volume group could not be created due to a false positive by the `exists?` method of the provider.

The sample output of `lvs` in the spec tests was updated to this:

```
  LV      VG         Attr       LSize   Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
  lv_root VolGroup   -wi-ao----  18.54g
  lv_swap VolGroup   -wi-ao---- 992.00m
  data    data       -wi-ao---- 992.00m
  j1      vg_jenkins -wi-a-----   1.00g
```

After adding a test to verify that a logical volume named `jenkins` does not exist the original `exists?` check failed like so:

```
Puppet::Type::Logical_volume::ProviderLvm
  self.instances
    returns an array of logical volumes
  when checking existence
    returns 'true', lv 'data' in vg 'data' exists
    returns 'nil', lv 'jenkins' in vg 'vg_jenkins' exists (FAILED - 5)
    returns 'nil', lv 'data' in vg 'myvg' does not exist
```

After updating the `exists?` method to instead use `lvs_pattern` the new tests passes:

```
Puppet::Type::Logical_volume::ProviderLvm
  self.instances
    returns an array of logical volumes
  when checking existence
    returns 'true', lv 'data' in vg 'data' exists
    returns 'nil', lv 'jenkins' in vg 'vg_jenkins' exists
    returns 'nil', lv 'data' in vg 'myvg' does not exist
```

Co-authored-by: Ruediger Pluem <r.pluem@gmx.de>