### PR TITLE
Add a further test for #244

### DIFF
--- a/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
+++ b/spec/unit/puppet/provider/logical_volume/lvm_spec.rb
@@ -41,6 +41,12 @@ describe provider_class do
       @provider.class.stubs(:lvs).with('vg_jenkins').returns(lvs_output)
       expect(@provider.exists?).to be_nil
     end
+    it "returns 'nil', lv 'swap' in vg 'VolGroup' exists" do
+      @resource.expects(:[]).with(:name).returns('swap')
+      @resource.expects(:[]).with(:volume_group).returns('VolGroup').at_least_once
+      @provider.class.stubs(:lvs).with('VolGroup').returns(lvs_output)
+      expect(@provider.exists?).to be_nil
+    end
     it "returns 'nil', lv 'data' in vg 'myvg' does not exist" do
       @resource.expects(:[]).with(:volume_group).returns('myvg').at_least_once
       @provider.class.stubs(:lvs).with('myvg').raises(Puppet::ExecutionFailure, 'Execution of \'/sbin/lvs myvg\' returned 5')


### PR DESCRIPTION
Test that exists returns nil if the name of the logical volume is a
substring of the name of an existing logical volume.

(cherry picked from commit d64c11d098b940d3a2a0a96985adad75b8f46cb2)