### PR TITLE
Feature/add support for filesystem labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,12 +142,12 @@ If you need a more complex configuration, you'll need to build the
 resources out yourself.
 
 ## Optional Values
-  The `unless_vg` (physical_volume) and `createonly` (volume_group) will check 
+  The `unless_vg` (physical_volume) and `createonly` (volume_group) will check
   to see if "myvg" exists.  If "myvg" does exist then they will not modify
   the physical volume or volume_group.  This is useful if your environment
   is built with certain disks but they change while the server grows, shrinks
   or moves.
- 
+
   Example:
 ```puppet
     physical_volume { "/dev/hdc":
@@ -200,6 +200,7 @@ resources out yourself.
 * stripes (Parameter) - The number of stripes to allocate for the new logical volume.
 * stripesize (Parameter) - The stripesize to use for the new logical volume.
 * thinpool (Parameter) - Default value: `false` - Set to true to create a thin pool or to pool name to create thin volume
+* use_fs_label (Parameter) - Default value: `false` - Set to true to create and mount the filesystem with a label (e.g. `mkfs.ext4 -L foobar` and `mount LABEL=foobar /mnt`). The value is taken from the resource-title.
 * volume_group (Parameter) - The volume group name associated with this logical volume. This will automatically set this volume group as a dependency, but it must be defined elsewhere using the volume_group resource type.
 
 ### physical_volume

--- a/manifests/volume_group.pp
+++ b/manifests/volume_group.pp
@@ -6,23 +6,25 @@ define lvm::volume_group (
   Enum['present', 'absent'] $ensure = present,
   Hash $logical_volumes             = {},
   Boolean $followsymlinks           = false,
+  Boolean $manage_pv                = true,
 ) {
 
-  if is_hash($physical_volumes) {
-    create_resources(
-      'lvm::physical_volume',
-      $physical_volumes,
-      {
-        ensure           => $ensure,
+  if $manage_pv {
+    if is_hash($physical_volumes) {
+      create_resources(
+        'lvm::physical_volume',
+        $physical_volumes,
+        {
+          ensure           => $ensure,
+        }
+      )
+    }
+    else {
+      physical_volume { $physical_volumes:
+        ensure => $ensure,
       }
-    )
-  }
-  else {
-    physical_volume { $physical_volumes:
-      ensure => $ensure,
     }
   }
-
 
   volume_group { $name:
     ensure           => $ensure,

--- a/tests/beaker/tests/create_filesystem_with_fs_label.rb
+++ b/tests/beaker/tests/create_filesystem_with_fs_label.rb
@@ -1,0 +1,56 @@
+require 'master_manipulator'
+require 'lvm_helper'
+require 'securerandom'
+
+test_name "FM-4615 - C96570 - create filesystem with parameter 'use_fs_label'"
+
+# initilize
+pv = '/dev/sdc'
+vg = ('VolumeGroup_' + SecureRandom.hex(2))
+lv = ('fslabel' + SecureRandom.hex(3))
+
+# Teardown
+teardown do
+  confine_block(:except, roles: ['master', 'dashboard', 'database']) do
+    agents.each do |agent|
+      remove_all(agent, pv, vg, lv)
+    end
+  end
+end
+
+pp = <<-MANIFEST
+physical_volume {'#{pv}':
+  ensure  => present,
+}
+->
+volume_group {'#{vg}':
+  ensure            => present,
+  physical_volumes  => '#{pv}',
+}
+->
+logical_volume{'#{lv}':
+  ensure        => present,
+  volume_group  => '#{vg}',
+  size          => '20M',
+  use_fs_label  => true,
+  createfs      => true,
+  fs_type       => 'ext4',
+  options       => '-b 4096 -E stride=32,stripe-width=64',
+}
+MANIFEST
+
+step 'Inject "site.pp" on Master'
+site_pp = create_site_pp(master, manifest: pp)
+inject_site_pp(master, get_site_pp_path(master), site_pp)
+
+step 'Run Puppet Agent to create logical volumes'
+confine_block(:except, roles: ['master', 'dashboard', 'database']) do
+  agents.each do |agent|
+    on(agent, puppet('agent -t --environment production'), acceptable_exit_codes: [0, 2]) do |result|
+      assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+    end
+
+    step "Verify the logical volume has correct format type: #{lv}"
+    is_correct_format?(agent, vg, lv, 'ext4')
+  end
+end


### PR DESCRIPTION
_e.g._

```yaml
    logical_volumes:
      opt:
        size: 20G
        use_fs_label: true
```

will then lead to

* formating the filesystem by `mkfs.ext4 -L opt /dev/vg-xyz/opt`. the most `mkfs`'s implement the `-L` label-parameter. So it shouldn't be necessary to make it configurable.
* _/etc/fstab_ entry `LABEL=opt /opt ext4 defaults 0 0`

