### PR TITLE
Fix `undefined method '[]' for nil:NilClass` when creating filesystem…

### DIFF
--- a/lib/puppet/provider/filesystem/lvm.rb
+++ b/lib/puppet/provider/filesystem/lvm.rb
@@ -18,7 +18,12 @@ Puppet::Type.type(:filesystem).provide :lvm do
   end
 
   def fstype
-    %r{\bTYPE=\"(\S+)\"}.match(blkid(@resource[:name]))[1]
+    type_match = %r{\bTYPE=\"(\S+)\"}.match(blkid(@resource[:name]))
+    # when creating FS on a non LVM partition that already exists but does not have FS
+    # blkid output does not contain `TYPE=....` -> type_match is nil
+    if type_match
+      type_match[1]
+    end
   rescue Puppet::ExecutionFailure
     nil
   end


### PR DESCRIPTION
The `filesystem` resource of this module is useful for creating filesystems even outside of the LVM.
When we want to create a filesystem on a partition not created by LVM, the `filesystem` resource fails with the following error:
```
Filesystem[/dev/sdb2]: Could not evaluate: undefined method `[]' for nil:NilClass
```
The current code only catches non zero return codes from `blkid` when checking on logical volumes. On LVM volumes  with no filesystem, the `blkid` fails with return code 2 and that is catched and the function `fstype` returns `nil`
```
# blkid /dev/vg-nvme/test
# echo $?
2
```

But when we want to apply it to a partition that was not created by LVM that does not have filesystem  yet, the `blkid` run succeeds, but the output is not as expected by this module. It misses the `TYPE="   "` part.
Example:
partition without FS
```
# blkid /dev/sdb3
/dev/sdb3: PARTUUID="1b29bbd9-03"
```
partition with fs
```
# blkid /dev/sdb2
/dev/sdb2: UUID="5d7aa665-26d6-455f-89b7-084628b88791" TYPE="ext4" PARTUUID="1b29bbd9-02"
```
When it happens, the pattern matching does not find the `TYPE` and the result is `nil`. Therefore it fails with the above mentioned error. 

This PR introduces a fix that checks the value before trying to use the `[1]` indexing. If `TYPE` was not found, it returns `nil`, as before.

Thanks for the good work on the LVM module :)
