### PR TITLE
workaround for removing an empty (no fs) logical volume

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -149,7 +149,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
 
   def destroy
     name_escaped = "#{@resource[:volume_group].gsub('-', '--')}-#{@resource[:name].gsub('-', '--')}"
-    if File.exist?(path) and blkid(path) =~ %r{\bTYPE=\"(swap)\"}
+    if File.exist?(path) && blkid(path) =~ %r{\bTYPE=\"(swap)\"}
       swapoff(path)
       dmsetup('remove', name_escaped)
     end

--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -151,8 +151,8 @@ Puppet::Type.type(:logical_volume).provide :lvm do
     name_escaped = "#{@resource[:volume_group].gsub('-', '--')}-#{@resource[:name].gsub('-', '--')}"
     if File.exist?(path) and blkid(path) =~ %r{\bTYPE=\"(swap)\"}
       swapoff(path)
+      dmsetup('remove', name_escaped)
     end
-    dmsetup('remove', name_escaped)
     lvremove('-f', path)
   end
 

--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -149,7 +149,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
 
   def destroy
     name_escaped = "#{@resource[:volume_group].gsub('-', '--')}-#{@resource[:name].gsub('-', '--')}"
-    if blkid(path) =~ %r{\bTYPE=\"(swap)\"}
+    if File.exist?(path) and blkid(path) =~ %r{\bTYPE=\"(swap)\"}
       swapoff(path)
     end
     dmsetup('remove', name_escaped)


### PR DESCRIPTION
blkid returns error code 2 if a path does not exist, which causes puppet to bail and not remove the lv.

A similar issue was already fixed for resizing (https://github.com/puppetlabs/puppetlabs-lvm/pull/188/files).

It may be better to wrap the blkid call somehow, since it is used multiple times in the code and has more than one valid exit code.