### PR TITLE
blkid returning 2 is not an error in this case

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -155,7 +155,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
       ## If blkid returned 2, there is no filesystem present or the file doesn't exist.  This should not be a failure.
       if detail.message =~ %r{ returned 2:}
         Puppet.debug(detail.message)
-	isswap = false
+        isswap = false
       else
         raise
       end


### PR DESCRIPTION
blkid returns error code 2 if a path does not exist, which causes puppet to bail and not remove the lv.

A similar issue was already fixed for resizing (https://github.com/puppetlabs/puppetlabs-lvm/pull/188/files).

It may be better to wrap the blkid call somehow, since it is used multiple times in the code and has more than one valid exit code.