### PR TITLE
lvm_support: update fact to use --no-headings

### DIFF
--- a/lib/facter/lvm_support.rb
+++ b/lib/facter/lvm_support.rb
@@ -33,10 +33,13 @@ vg_list.each_with_index do |vg, i|
   Facter.add("lvm_vg_#{i}") { setcode { vg } }
   Facter.add("lvm_vg_#{vg}_pvs") do
     setcode do
-      pvs = Facter::Core::Execution.execute("vgs -o pv_name #{vg} 2>/dev/null", timeout: 30)
+      pvs = Facter::Core::Execution.execute(
+        "vgs -o pv_name --noheadings #{vg} 2>/dev/null",
+        timeout: 30,
+      )
       res = nil
       unless pvs.nil?
-        res = pvs.split("\n").select { |l| l =~ %r{^\s+/} }.map(&:strip).sort.join(',')
+        res = pvs.split("\n").map(&:strip).sort.join(',')
       end
       res
     end

--- a/spec/unit/facter/lvm_support_spec.rb
+++ b/spec/unit/facter/lvm_support_spec.rb
@@ -63,8 +63,8 @@ describe 'lvm_vgs facts' do
       it 'lists vgs' do
         Facter::Core::Execution.stubs(:execute) # All other calls
         Facter::Core::Execution.expects(:execute).at_least(1).with('vgs -o name --noheadings 2>/dev/null', timeout: 30).returns("vg0\nvg1")
-        Facter::Core::Execution.expects(:execute).at_least(1).with('vgs -o pv_name vg0 2>/dev/null', timeout: 30).returns("  PV\n  /dev/pv3\n  /dev/pv2")
-        Facter::Core::Execution.expects(:execute).at_least(1).with('vgs -o pv_name vg1 2>/dev/null', timeout: 30).returns("  PV\n  /dev/pv0")
+        Facter::Core::Execution.expects(:execute).at_least(1).with('vgs -o pv_name --noheadings vg0 2>/dev/null', timeout: 30).returns("  /dev/pv3\n  /dev/pv2")
+        Facter::Core::Execution.expects(:execute).at_least(1).with('vgs -o pv_name --noheadings vg1 2>/dev/null', timeout: 30).returns('  /dev/pv0')
         Facter.fact(:lvm_support).expects(:value).at_least(1).returns(true)
         Facter.value(:lvm_vgs).should == 2
         Facter.value(:lvm_vg_0).should == 'vg0'


### PR DESCRIPTION
I noticed upgrading that the `lvm_vg_#{vg}_pv` facts dose not use
the `--no-headings` switch like the other facts.

This PR adds the `--no-headings` switch and simplifies the collection