### PR TITLE
(MODULES-11011) extend vg facts

### DIFF
--- a/lib/facter/volume_groups.rb
+++ b/lib/facter/volume_groups.rb
@@ -20,9 +20,12 @@ Facter.add(:volume_groups) do
       'vg_allocation_policy',
       'vg_size',
       'vg_free',
+      'vg_extent_size',
+      'vg_extent_count',
+      'vg_free_count',
     ]
 
-    output = Facter::Core::Execution.exec("vgs -o #{columns.join(',')}  --noheading --nosuffix")
+    output = Facter::Core::Execution.exec("vgs -o #{columns.join(',')}  --noheading --nosuffix --units m")
     Puppet_X::LVM::Output.parse('vg_name', columns, output)
   end
 end

--- a/spec/unit/facter/volume_groups_spec.rb
+++ b/spec/unit/facter/volume_groups_spec.rb
@@ -8,7 +8,7 @@ describe 'volume_groups fact' do
   context 'when not on Linux' do
     it 'is set to nil' do
       Facter.fact(:kernel).expects(:value).at_least(1).returns('SunOs')
-      Facter.value(:volume_groups).should be_nil
+      expect(Facter.value(:volume_groups)).to be_nil
     end
   end
 
@@ -24,7 +24,7 @@ describe 'volume_groups fact' do
       end
 
       it 'is set to nil' do
-        Facter.value(:volume_groups).should be_nil
+        expect(Facter.value(:volume_groups)).to be_nil
       end
     end
 
@@ -36,26 +36,34 @@ describe 'volume_groups fact' do
 
       it 'is able to resolve vgs' do
         vgs_output = <<-OUTPUT
-          ZcFkEG-217a-nnc6-PvWx-oXou-7THt-XR6eci centos wz--n- writeable  normal     19.51g 44.00m
-          tMqdQC-ukEx-bEft-bLk8-WoM1-jX0a-0p1rri tasks  wz--n- writeable  normal      3.99g  2.82g
+          ZcFkEG-217a-nnc6-PvWx-oXou-7THt-XR6eci centos wz--n- writeable  normal     953864,00 126472,00 4,00 238466 31618
+          tMqdQC-ukEx-bEft-bLk8-WoM1-jX0a-0p1rri tasks  wz--n- writeable  normal      55540,00   6388,00 4,00  13885  1597
         OUTPUT
         vgs_output.lstrip!
         Facter::Core::Execution.expects(:exec).at_least(1).returns(vgs_output)
-        Facter.value(:volume_groups).should include('centos' => {
-                                                      'uuid' => 'ZcFkEG-217a-nnc6-PvWx-oXou-7THt-XR6eci',
-                                                      'attr'              => 'wz--n-', 'permissions' => 'writeable',
-                                                      'allocation_policy' => 'normal',
-                                                      'size'              => '19.51g',
-                                                      'free'              => '44.00m'
-                                                    },
-                                                    'tasks' => {
-                                                      'uuid' => 'tMqdQC-ukEx-bEft-bLk8-WoM1-jX0a-0p1rri',
-                                                      'attr'              => 'wz--n-',
-                                                      'permissions'       => 'writeable',
-                                                      'allocation_policy' => 'normal',
-                                                      'size'              => '3.99g',
-                                                      'free'              => '2.82g',
-                                                    })
+        expect(Facter.value(:volume_groups)).to include(
+          'centos' => {
+            'uuid'              => 'ZcFkEG-217a-nnc6-PvWx-oXou-7THt-XR6eci',
+            'attr'              => 'wz--n-', 'permissions' => 'writeable',
+            'allocation_policy' => 'normal',
+            'size'              => '953864,00',
+            'free'              => '126472,00',
+            'extent_size'       => '4,00',
+            'extent_count'      => '238466',
+            'free_count'        => '31618'
+          },
+          'tasks'  => {
+            'uuid' => 'tMqdQC-ukEx-bEft-bLk8-WoM1-jX0a-0p1rri',
+            'attr'              => 'wz--n-',
+            'permissions'       => 'writeable',
+            'allocation_policy' => 'normal',
+            'size'              => '55540,00',
+            'free'              => '6388,00',
+            'extent_size'       => '4,00',
+            'extent_count'      => '13885',
+            'free_count'        => '1597',
+          },
+        )
       end
     end
   end


### PR DESCRIPTION
Adds facts for the extends in the volume groups (size, count, free extends)
Also sets the units to megabytes (of 1024k)
Otherwise the --nosuffix option was not used, and we could get results like '<54,24g'

Ref: MODULES-11011