### PR TITLE
Be consistent when calculating sizes

### DIFF
--- a/functions/bytes_to_size.pp
+++ b/functions/bytes_to_size.pp
@@ -2,6 +2,7 @@ function lvm::bytes_to_size (
   Numeric $size,
 ) {
   $units = {
+    'b' => 1,
     'k' => 1024,
     'm' => 1048576,
     'g' => 1073741824,
@@ -18,7 +19,7 @@ function lvm::bytes_to_size (
   # Use the last unit
   $largest_unit = $remaining_units.keys[-1]
 
-  $value = ($size / $units[$largest_unit])
+  $value = (Float($size) / $units[$largest_unit])
 
   # # Return the string
   "${value}${largest_unit}"

--- a/functions/size_to_bytes.pp
+++ b/functions/size_to_bytes.pp
@@ -2,6 +2,7 @@ function lvm::size_to_bytes (
   String $size,
 ) {
   $units = {
+    'B' => 1,
     'K' => 1024,
     'M' => 1048576,
     'G' => 1073741824,
@@ -10,7 +11,7 @@ function lvm::size_to_bytes (
     'E' => 1.1529215e18,
   }
   # Check if the size is valid and if so, extract the units
-  if $size =~ /^([0-9]+(\.[0-9]+)?)([KMGTPEkmgtpe])/ {
+  if $size =~ /^([0-9]+(\.[0-9]+)?)([BKMGTPEbkmgtpe])/ {
     $unit   = String($3, '%u') # Store the units in uppercase
     $number = Float($1)       # Store the number as a float
 


### PR DESCRIPTION
Ensure that passing the size as integer yields the same result as
passing the size as float.
Also support sizes below 1 KiB.

Before:
```
lvm::size_to_bytes(lvm::bytes_to_size(2047))   # 1024.0
lvm::size_to_bytes(lvm::bytes_to_size(2047.0)) # 2047.0
lvm::bytes_to_size(1023) # Evaluation Error: The value '' cannot be converted to Numeric.
```

After:
```
lvm::size_to_bytes(lvm::bytes_to_size(2047))   # 2047.0
lvm::size_to_bytes(lvm::bytes_to_size(2047.0)) # 2047.0
lvm::bytes_to_size(1023) # 1023.0b
```
