### PR TITLE
size_to_bytes failes when output of lvs contains <

### DIFF
--- a/functions/size_to_bytes.pp
+++ b/functions/size_to_bytes.pp
@@ -20,3 +20,4 @@ function lvm::size_to_bytes (
     fail("${size} is not a valid LVM size")
   }
 }
+

--- a/functions/size_to_bytes.pp
+++ b/functions/size_to_bytes.pp
@@ -10,7 +10,7 @@ function lvm::size_to_bytes (
     'E' => 1.1529215e18,
   }
   # Check if the size is valid and if so, extract the units
-  if $size =~ /^([0-9]+(\.[0-9]+)?)([KMGTPEkmgtpe])/ {
+  if $size =~ /^<?([0-9]+(\.[0-9]+)?)([KMGTPEkmgtpe])/ {
     $unit   = String($3, '%u') # Store the units in uppercase
     $number = Float($1)       # Store the number as a float
 


### PR DESCRIPTION
Example of lvs output where previous regular expression fails:

$ sudo lvs
  LV   VG   Attr       LSize   Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
  root rhel -wi-ao---- <21.50g
  swap rhel -wi-ao----   2.50g
