### PR TITLE
Bump stdlib dependency to v9

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 7.0.0"
+      "version_requirement": ">= 4.13.1 < 9.0.0"
     },
     {
       "name": "puppetlabs/mount_core",


### PR DESCRIPTION
stdlib v9 is easily supported as there are no breaking changes relating to anything but Puppet/OS compatiblity.