### PR TITLE
fix in logical_volume provider, function "exists": false matches.

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -161,7 +161,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
 
     def exists?
         begin
-            lvs(@resource[:volume_group]) =~ /#{@resource[:name]}/
+            lvs('-o', 'name', '--unbuffered', @resource[:volume_group]) =~ /^ *#{@resource[:name]}$/
         rescue Puppet::ExecutionFailure
             # lvs fails if we give it an empty volume group name, as would
             # happen if we were running `puppet resource`. This should be


### PR DESCRIPTION
eg. check for lv_mysql would return true is lv_mysqllog exists.
This can be fixed by improving the regex searching for the name of the LV.
jira reference: https://tickets.puppetlabs.com/browse/CPR-863 