### PR TITLE
pdksync - (MAINT) - Allow Stdlib 9.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 9.0.0"
+      "version_requirement": ">= 4.13.1 < 10.0.0"
     },
     {
       "name": "puppetlabs/mount_core",


### PR DESCRIPTION
(MAINT) - Update Stdlib dependency
pdk version: `2.5.0` 

Fixes https://github.com/puppetlabs/puppetlabs-lvm/issues/285