### PR TITLE
(gh-290) - fix broken datatype for extents

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -458,7 +458,7 @@ Default value: `undef`
 
 ##### <a name="-lvm--volume--extents"></a>`extents`
 
-Data type: `Optional[Variant[String[1], Integert]]`
+Data type: `Optional[Variant[String[1], Integer]]`
 
 
 

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -67,7 +67,7 @@ define lvm::volume (
   Stdlib::Absolutepath $vg,
   Optional[String[1]] $fstype                     = undef,
   Optional[String[1]] $size                       = undef,
-  Optional[Variant[String[1], Integert]] $extents = undef,
+  Optional[Variant[String[1], Integer]] $extents  = undef,
   Optional[String[1]] $initial_size               = undef
 ) {
   if ($name == undef) {


### PR DESCRIPTION
Fixes a typo with the extents parameter in volume.pp.

Fixes https://github.com/puppetlabs/puppetlabs-lvm/issues/290