### PR TITLE
[GH-298] fix lvm_vg_* facts

### DIFF
--- a/lib/facter/lvm_support.rb
+++ b/lib/facter/lvm_support.rb
@@ -13,31 +13,34 @@ end
 
 # lvm_vgs: [0-9]+
 #   Number of VGs
+vg_list = []
 Facter.add('lvm_vgs') do
   confine lvm_support: true
 
-  setcode do
+  if Facter.value(:lvm_support)
     vgs = Facter::Core::Execution.execute('vgs -o name --noheadings 2>/dev/null', timeout: 30)
+  end
 
-    if vgs.nil?
-      0
-    else
-      vg_list = vgs.split
+  if vgs.nil?
+    setcode { 0 }
+  else
+    vg_list = vgs.split
+    setcode { vg_list.length }
+  end
+end
 
-      # lvm_vg_[0-9]+
-      #   VG name by index
-      vg_list.each_with_index do |vg, i|
-        Facter.add("lvm_vg_#{i}") { setcode { vg } }
-        Facter.add("lvm_vg_#{vg}_pvs") do
-          setcode do
-            pvs = Facter::Core::Execution.execute("vgs -o pv_name #{vg} 2>/dev/null", timeout: 30)
-            res = nil
-            res = pvs.split("\n").grep(%r{^\s+/}).collect(&:strip).sort.join(',') unless pvs.nil?
-            res
-          end
-        end
+# lvm_vg_[0-9]+
+#   VG name by index
+vg_list.each_with_index do |vg, i|
+  Facter.add("lvm_vg_#{i}") { setcode { vg } }
+  Facter.add("lvm_vg_#{vg}_pvs") do
+    setcode do
+      pvs = Facter::Core::Execution.execute("vgs -o pv_name #{vg} 2>/dev/null", timeout: 30)
+      res = nil
+      unless pvs.nil?
+        res = pvs.split("\n").select { |l| l =~ %r{^\s+/} }.map(&:strip).sort.join(',')
       end
-      vg_list.length
+      res
     end
   end
 end
@@ -47,21 +50,20 @@ end
 pv_list = []
 Facter.add('lvm_pvs') do
   confine lvm_support: true
-
-  setcode do
+  if Facter.value(:lvm_support)
     pvs = Facter::Core::Execution.execute('pvs -o name --noheadings 2>/dev/null', timeout: 30)
-
-    if pvs.nil?
-      0
-    else
-      pv_list = pvs.split
-
-      # lvm_pv_[0-9]+
-      #   PV name by index
-      pv_list.each_with_index do |pv, i|
-        Facter.add("lvm_pv_#{i}") { setcode { pv } }
-      end
-      pv_list.length
-    end
   end
+
+  if pvs.nil?
+    setcode { 0 }
+  else
+    pv_list = pvs.split
+    setcode { pv_list.length }
+  end
+end
+
+# lvm_pv_[0-9]+
+#   PV name by index
+pv_list.each_with_index do |pv, i|
+  Facter.add("lvm_pv_#{i}") { setcode { pv } }
 end

--- a/lib/facter/lvm_support.rb
+++ b/lib/facter/lvm_support.rb
@@ -17,9 +17,7 @@ vg_list = []
 Facter.add('lvm_vgs') do
   confine lvm_support: true
 
-  if Facter.value(:lvm_support)
-    vgs = Facter::Core::Execution.execute('vgs -o name --noheadings 2>/dev/null', timeout: 30)
-  end
+  vgs = Facter::Core::Execution.execute('vgs -o name --noheadings 2>/dev/null', timeout: 30)
 
   if vgs.nil?
     setcode { 0 }
@@ -50,10 +48,8 @@ end
 pv_list = []
 Facter.add('lvm_pvs') do
   confine lvm_support: true
-  if Facter.value(:lvm_support)
-    pvs = Facter::Core::Execution.execute('pvs -o name --noheadings 2>/dev/null', timeout: 30)
-  end
 
+  pvs = Facter::Core::Execution.execute('pvs -o name --noheadings 2>/dev/null', timeout: 30)
   if pvs.nil?
     setcode { 0 }
   else

--- a/spec/unit/facter/lvm_support_spec.rb
+++ b/spec/unit/facter/lvm_support_spec.rb
@@ -54,7 +54,7 @@ describe 'lvm_vgs facts' do
   context 'when there is lvm support' do
     context 'when there are no vgs' do
       it 'is set to 0' do
-        Facter::Core::Execution.stubs(:execute) # All other calls
+        allow(Facter::Core::Execution).to receive(:execute) # All other calls
         Facter::Core::Execution.expects(:execute).at_least(1).with('vgs -o name --noheadings 2>/dev/null', timeout: 30).returns(nil)
         Facter.fact(:lvm_support).expects(:value).at_least(1).returns(true)
         Facter.value(:lvm_vgs).should == 0

--- a/spec/unit/facter/lvm_support_spec.rb
+++ b/spec/unit/facter/lvm_support_spec.rb
@@ -54,7 +54,7 @@ describe 'lvm_vgs facts' do
   context 'when there is lvm support' do
     context 'when there are no vgs' do
       it 'is set to 0' do
-        allow(Facter::Core::Execution).to receive(:execute) # All other calls
+        Facter::Core::Execution.stubs(:execute) # All other calls
         Facter::Core::Execution.expects(:execute).at_least(1).with('vgs -o name --noheadings 2>/dev/null', timeout: 30).returns(nil)
         Facter.fact(:lvm_support).expects(:value).at_least(1).returns(true)
         Facter.value(:lvm_vgs).should == 0
@@ -64,7 +64,7 @@ describe 'lvm_vgs facts' do
     context 'when there are vgs' do
       it 'lists vgs' do
         Facter::Core::Execution.stubs(:execute) # All other calls
-        Facter::Core::Execution.expects(:execute).at_least(1).with('vgs -o name --noheadings 2>/dev/null', timeout: 30).returns("vg0\nvg1")
+        Facter::Core::Execution.expects(:execute).at_least(1).with('vgs -o name --noheadings 2>/dev/null', timeout: 30).returns("  vg0\n  vg1")
         Facter::Core::Execution.expects(:execute).at_least(1).with('vgs -o pv_name vg0 2>/dev/null', timeout: 30).returns("  PV\n  /dev/pv3\n  /dev/pv2")
         Facter::Core::Execution.expects(:execute).at_least(1).with('vgs -o pv_name vg1 2>/dev/null', timeout: 30).returns("  PV\n  /dev/pv0")
         Facter.fact(:lvm_support).expects(:value).at_least(1).returns(true)
@@ -86,7 +86,6 @@ describe 'lvm_pvs facts' do
 
   context 'when there is no lvm support' do
     it 'does not exist' do
-      Facter.fact(:lvm_support).expects(:value).at_least(1).returns(nil)
       Facter.value(:lvm_pvs).should be_nil
     end
   end
@@ -104,7 +103,7 @@ describe 'lvm_pvs facts' do
     context 'when there are pvs' do
       it 'lists pvs' do
         Facter::Core::Execution.stubs('execute') # All other calls
-        Facter::Core::Execution.expects('execute').at_least(1).with('pvs -o name --noheadings 2>/dev/null', timeout: 30).returns("pv0\npv1")
+        Facter::Core::Execution.expects('execute').at_least(1).with('pvs -o name --noheadings 2>/dev/null', timeout: 30).returns("  pv0\n  pv1")
         Facter.fact(:lvm_support).expects(:value).at_least(1).returns(true)
         Facter.value(:lvm_pvs).should == 2
         Facter.value(:lvm_pv_0).should == 'pv0'


### PR DESCRIPTION
## Summary
This is reverting https://github.com/puppetlabs/puppetlabs-lvm/commit/8e1e8eb1718f31a75d9edf79b123c74d61364e55 and fixing the spec tests other way.

## Additional Context
See issue #298 

## Related Issues (if any)
Closes #298 .

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)
