### PR TITLE
remove puppetlabs/mount_core from metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,10 +11,6 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.13.1 < 10.0.0"
-    },
-    {
-      "name": "puppetlabs/mount_core",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
The *_core modules are internal modules and vendored within Puppet AIO. They should not be added to metadata.json.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)
