### PR TITLE
(CAT-1696) - Fixing pipeline for ARM architecture

### DIFF
--- a/spec/acceptance/create_filesystem_spec.rb
+++ b/spec/acceptance/create_filesystem_spec.rb
@@ -4,9 +4,13 @@ require 'spec_helper_acceptance'
 require 'securerandom'
 
 describe 'create filesystems' do
+  let(:device_name) do
+    (os[:arch] == 'aarch64') ? 'nvme0n3' : 'sdc'
+  end
+
   describe 'create_filesystem_non-existing-format' do
     let(:pv) do
-      '/dev/sdc'
+      "/dev/#{device_name}"
     end
     let(:vg) do
       'VolumeGroup'
@@ -47,7 +51,7 @@ describe 'create filesystems' do
 
   describe 'create_filesystem_with_ensure_property_ext2' do
     let(:pv) do
-      '/dev/sdc'
+      "/dev/#{device_name}"
     end
     let(:vg) do
       'VolumeGroup_ext2'
@@ -89,7 +93,7 @@ describe 'create filesystems' do
 
   describe 'create_filesystem_with_ensure_property_ext4' do
     let(:pv) do
-      '/dev/sdc'
+      "/dev/#{device_name}"
     end
     let(:vg) do
       'VolumeGroup_ext4'

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -134,17 +134,18 @@ end
 RSpec.configure do |c|
   disks = ['sdb', 'sdc']
   hostname = LitmusHelper.instance.run_shell('hostname').stdout.strip.gsub(%r{\..*$}, '')
+  zone = LitmusHelper.instance.run_shell('curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/zone').stdout.strip.gsub(%r{.*zones/}, '')
   c.before :suite do
     install_dependencies
     disks.each do |disk|
-      LitmusHelper.instance.run_shell("gcloud compute disks create #{hostname}-#{disk} --size 10GB --type pd-standard --zone=us-west1-c")
-      LitmusHelper.instance.run_shell("gcloud compute instances attach-disk #{hostname} --disk #{hostname}-#{disk} --zone=us-west1-c")
+      LitmusHelper.instance.run_shell("gcloud compute disks create #{hostname}-#{disk} --size 10GB --type pd-standard --zone=#{zone}")
+      LitmusHelper.instance.run_shell("gcloud compute instances attach-disk #{hostname} --disk #{hostname}-#{disk} --zone=#{zone}")
     end
   end
   c.after :suite do
     disks.each do |disk|
-      LitmusHelper.instance.run_shell("gcloud compute instances detach-disk #{hostname} --disk=#{hostname}-#{disk} --zone=us-west1-c --quiet")
-      LitmusHelper.instance.run_shell("gcloud compute disks delete #{hostname}-#{disk} --zone=us-west1-c --quiet")
+      LitmusHelper.instance.run_shell("gcloud compute instances detach-disk #{hostname} --disk=#{hostname}-#{disk} --zone=#{zone} --quiet")
+      LitmusHelper.instance.run_shell("gcloud compute disks delete #{hostname}-#{disk} --zone=#{zone} --quiet")
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixing pipeline for ARM architecture due to the NVME device type for ARM OS.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)
