### PR TITLE
Documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ parameters documented above also apply to AIX systems.
 * vix (Parameter) - Specify that the file system can allocate inode extents smaller than the default, Allowed Values:
     * `true`
     * `false`
-* volume_group (Parameter) - Volume group that the file system should be greated on.
+* volume_group (Parameter) - Volume group that the file system should be created on.
 
 ### logical_volume
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ This could be really convenient when used with hiera:
 ```puppet
 include lvm
 ```
+
 and
+
 ```yaml
 ---
 lvm::volume_groups:
@@ -104,7 +106,9 @@ lvm::volume_groups:
         mountpath: /var/backups
         mountpath_require: true
 ```
+
 or to just build the VG if it does not exist
+
 ```yaml
 ---
 lvm::volume_groups:
@@ -142,13 +146,15 @@ If you need a more complex configuration, you'll need to build the
 resources out yourself.
 
 ## Optional Values
-  The `unless_vg` (physical_volume) and `createonly` (volume_group) will check
-  to see if "myvg" exists.  If "myvg" does exist then they will not modify
-  the physical volume or volume_group.  This is useful if your environment
-  is built with certain disks but they change while the server grows, shrinks
-  or moves.
 
-  Example:
+The `unless_vg` (physical_volume) and `createonly` (volume_group) will check
+to see if "myvg" exists.  If "myvg" does exist then they will not modify
+the physical volume or volume_group.  This is useful if your environment
+is built with certain disks but they change while the server grows, shrinks
+or moves.
+
+Example:
+
 ```puppet
     physical_volume { "/dev/hdc":
         ensure => present,
@@ -224,10 +230,8 @@ resources out yourself.
 
 ## AIX Specific Type Documentation
 
-
 There are a number of AIX specific parameters and properties. The regular
 parameters documented above also apply to AIX systems.
-
 
 ### filesystem
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ migration, etc.
 
 ## Deprecation Notice
 
-Some facts reported by this module are being deprecated in favor of upcomming structured facts.  The following facts are being deprecated:
+Some facts reported by this module are being deprecated in favor of upcoming structured facts.  The following facts are being deprecated:
 
 * `lvm_vg_*`
 * `lvm_vg_*_pvs`
@@ -399,4 +399,4 @@ Raphaël Pinson <raphael.pinson@camptocamp.com>
 
 Garrett Honeycutt <code@garretthoneycutt.com>
 
-[More Contributers](https://github.com/puppetlabs/puppetlabs-lvm/graphs/contributors)
+[More Contributors](https://github.com/puppetlabs/puppetlabs-lvm/graphs/contributors)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ class { 'lvm':
 This could be really convenient when used with hiera:
 
 ```puppet
-include ::lvm
+include lvm
 ```
 and
 ```yaml

--- a/README.md
+++ b/README.md
@@ -156,15 +156,16 @@ or moves.
 Example:
 
 ```puppet
-    physical_volume { "/dev/hdc":
-        ensure => present,
-        unless_vg => "myvg"
-    }
-    volume_group { "myvg":
-        ensure => present,
-        physical_volumes => "/dev/hdc",
-        createonly => true
-    }
+physical_volume { "/dev/hdc":
+  ensure    => present,
+  unless_vg => "myvg",
+}
+
+volume_group { "myvg":
+  ensure           => present,
+  physical_volumes => "/dev/hdc",
+  createonly       => true,
+}
 ```
 
 ## Type Documentation

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -722,7 +722,7 @@ Specify that the file system can allocate inode extents smaller than the default
 
 ##### <a name="-filesystem--volume_group"></a>`volume_group`
 
-Volume group that the file system should be greated on. AIX only.
+Volume group that the file system should be created on. AIX only.
 
 ### <a name="logical_volume"></a>`logical_volume`
 
@@ -1204,7 +1204,7 @@ Device to create the filesystem on, this can be a device or a logical volume. AI
 
 Data type: `Optional[String]`
 
-Volume group that the file system should be greated on. AIX only.
+Volume group that the file system should be created on. AIX only.
 
 ### <a name="ensure_lv"></a>`ensure_lv`
 

--- a/lib/puppet/type/filesystem.rb
+++ b/lib/puppet/type/filesystem.rb
@@ -138,7 +138,7 @@ Puppet::Type.newtype(:filesystem) do
   end
 
   newparam(:volume_group) do
-    desc 'Volume group that the file system should be greated on. AIX only.'
+    desc 'Volume group that the file system should be created on. AIX only.'
   end
 
   autorequire(:logical_volume) do

--- a/tasks/ensure_fs.json
+++ b/tasks/ensure_fs.json
@@ -115,7 +115,7 @@
       "type": "Optional[String]"
     },
     "volume_group": {
-      "description": "Volume group that the file system should be greated on. AIX only.",
+      "description": "Volume group that the file system should be created on. AIX only.",
       "type": "Optional[String]"
     }
   }


### PR DESCRIPTION
- README: don't use deprecated top-scope syntax
- README: fix formatting
- README: fix spelling
