### PR TITLE
Allow modifying the physical extent size for volume groups

### DIFF
--- a/lib/puppet/provider/volume_group/lvm.rb
+++ b/lib/puppet/provider/volume_group/lvm.rb
@@ -44,7 +44,12 @@ Puppet::Type.type(:volume_group).provide :lvm do
   end
 
   def create
-    vgcreate(@resource[:name], *@resource.should(:physical_volumes))
+    vgcreate_args = [@resource[:name], *@resource.should(:physical_volumes)]
+    extent_args = @resource[:extent_size].nil? ? [] : ['-s', @resource[:extent_size]]
+
+    vgcreate_args.append(*extent_args)
+
+    vgcreate(*vgcreate_args)
   end
 
   def destroy

--- a/lib/puppet/type/volume_group.rb
+++ b/lib/puppet/type/volume_group.rb
@@ -10,6 +10,10 @@ Puppet::Type.newtype(:volume_group) do
     isnamevar
   end
 
+  newparam(:extent_size) do
+    desc 'The physical extent size. Uses OS default if not provided. Only applicable on Linux.'
+  end
+
   newproperty(:physical_volumes, array_matching: :all) do
     desc "The list of physical volumes to be included in the volume group; this
          will automatically set these as dependencies, but they must be defined elsewhere

--- a/spec/unit/puppet/provider/volume_group/lvm_spec.rb
+++ b/spec/unit/puppet/provider/volume_group/lvm_spec.rb
@@ -28,11 +28,24 @@ describe provider_class do
   end
 
   describe 'when creating' do
-    it "executes 'vgcreate'" do
-      @resource.expects(:[]).with(:name).returns('myvg')
-      @resource.expects(:should).with(:physical_volumes).returns(['/dev/hda'])
-      @provider.expects(:vgcreate).with('myvg', '/dev/hda')
-      @provider.create
+    context 'when an extent size is not provided' do
+      it "executes 'vgcreate'" do
+        @resource.expects(:[]).with(:name).returns('myvg')
+        @resource.expects(:[]).with(:extent_size).returns(nil)
+        @resource.expects(:should).with(:physical_volumes).returns(['/dev/hda'])
+        @provider.expects(:vgcreate).with('myvg', '/dev/hda')
+        @provider.create
+      end
+    end
+
+    context 'when an extent size is provided' do
+      it "executes 'vgcreate' with the desired extent size" do
+        @resource.expects(:[]).with(:name).returns('myvg')
+        @resource.expects(:[]).twice.with(:extent_size).returns('16M')
+        @resource.expects(:should).with(:physical_volumes).returns(['/dev/hda'])
+        @provider.expects(:vgcreate).with('myvg', '/dev/hda', '-s', '16M')
+        @provider.create
+      end
     end
   end
 

--- a/spec/unit/puppet/type/volume_group_spec.rb
+++ b/spec/unit/puppet/type/volume_group_spec.rb
@@ -18,6 +18,12 @@ describe Puppet::Type.type(:volume_group) do
     end
   end
 
+  describe 'the extent_size parameter' do
+    it 'exists' do
+      @type.attrclass(:extent_size).should_not be_nil
+    end
+  end
+
   describe "the 'ensure' parameter" do
     it 'exists' do
       @type.attrclass(:ensure).should_not be_nil


### PR DESCRIPTION
## Summary
Allow modifying the physical extent size when creating new volume groups.

## Related Issues (if any)
Essentially replaces #332 

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)
