### PR TITLE
Allow for lvs to be created on specific pv

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -795,6 +795,7 @@ The following parameters are available in the `logical_volume` type.
 * [`name`](#-logical_volume--name)
 * [`no_sync`](#-logical_volume--no_sync)
 * [`persistent`](#-logical_volume--persistent)
+* [`physical_volume`](#-logical_volume--physical_volume)
 * [`poolmetadatasize`](#-logical_volume--poolmetadatasize)
 * [`provider`](#-logical_volume--provider)
 * [`range`](#-logical_volume--range)
@@ -840,6 +841,10 @@ An optimization in lvcreate, at least on Linux.
 ##### <a name="-logical_volume--persistent"></a>`persistent`
 
 Set to true to make the block device persistent
+
+##### <a name="-logical_volume--physical_volume"></a>`physical_volume`
+
+Create this logical volume on the specified physical volume
 
 ##### <a name="-logical_volume--poolmetadatasize"></a>`poolmetadatasize`
 

--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -120,6 +120,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
     end
 
     args.push('--yes') if @resource[:yes_flag]
+    args.push(@resource[:physical_volume]) if @resource[:physical_volume]
     lvcreate(*args)
   end
 

--- a/lib/puppet/type/logical_volume.rb
+++ b/lib/puppet/type/logical_volume.rb
@@ -119,6 +119,24 @@ Puppet::Type.newtype(:logical_volume) do
     end
   end
 
+  newparam(:physical_volume) do
+    desc "The physical volume name this logical volume will be created on"
+    validate do |val|
+      unless val.is_a?(::String) || val.is_a?(::Array)
+        raise ArgumentError, "physical_volume should be String or Array: #{val}"
+      end
+    end
+
+    munge do |val|
+      case val
+      when ::String
+        [val]
+      else
+        val
+      end
+    end
+  end
+
   newparam(:stripes) do
     desc 'The number of stripes to allocate for the new logical volume.'
     validate do |value|

--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -91,6 +91,7 @@ define lvm::logical_volume (
   Optional[Variant[String[1], Integer]] $region_size                            = undef,
   Optional[Enum['anywhere', 'contiguous', 'cling', 'inherit', 'normal']] $alloc = undef,
   Boolean $yes_flag                                                             = false,
+  Optional[Variant[Array[String],String]] $physical_volume                      = undef,
 ) {
   $lvm_device_path = "/dev/${volume_group}/${name}"
 
@@ -153,6 +154,7 @@ define lvm::logical_volume (
     region_size      => $region_size,
     alloc            => $alloc,
     yes_flag         => $yes_flag,
+    physical_volume  => $physical_volume,
   }
 
   if $createfs {


### PR DESCRIPTION
## Summary
This change allows the use of `physical_volume` as argument to `logical_volume` so that the new lv will be created on a specific physical volume even if the volume group consists of several physical volumes.

## Sample

```
    physical_volume { '/dev/sdb':
        ensure => present,
    }
    physical_volume { '/dev/sdc':
        ensure => present,
    }
    physical_volume { '/dev/sdd':
        ensure => present,
    }
    volume_group { 'lvmvg':
        ensure           => present,
        physical_volumes => [ '/dev/sdb', '/dev/sdc', '/dev/sdd']
    }
    logical_volume { 'testpool':
        poolmetadatasize => '256m',
        extents => "100%FREE",
        thinpool => true,
        volume_group => "lvmvg",
        physical_volume => [ "/dev/sdc", "/dev/sdd" ]
    }
```


## Related Issues
This is an updated and tweaked version of #212. 

