### PR TITLE
CAT-1912 : Adding new getters and setters for stripes & not allowing change of stripes for an existing lvm

### DIFF
--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -221,6 +221,22 @@ Puppet::Type.type(:logical_volume).provide :lvm do
     end
   end
 
+  def stripes
+    # Run the lvs command with the -o option to get only the stripes count
+    raw = (lvs '-o', 'stripes', '--noheadings', path)
+
+    output_array = raw.strip
+    output_array
+  end
+
+  def stripes=(new_stripes_count)
+    current_stripes = stripes.to_i
+
+    # Changing stripes is not supported for existing logical volumes
+    return unless new_stripes_count.to_i != current_stripes
+    raise(Puppet::Error, "Changing stripes from #{current_stripes} to #{new_stripes_count} is not supported for existing logical volumes")
+  end
+
   # Look up the current number of mirrors (0=no mirroring, 1=1 spare, 2=2 spares....). Return the number as string.
   def mirror
     raw = lvdisplay(path)

--- a/lib/puppet/type/logical_volume.rb
+++ b/lib/puppet/type/logical_volume.rb
@@ -119,7 +119,7 @@ Puppet::Type.newtype(:logical_volume) do
     end
   end
 
-  newparam(:stripes) do
+  newproperty(:stripes) do
     desc 'The number of stripes to allocate for the new logical volume.'
     validate do |value|
       raise ArgumentError, "#{value} is not a valid stripe count" unless %r{^[0-9]+$}i.match?(value.to_s)

--- a/spec/acceptance/create_filesystem_spec.rb
+++ b/spec/acceptance/create_filesystem_spec.rb
@@ -145,7 +145,7 @@ describe 'create filesystems' do
 
     it 'change the stripes and re-applies the manifest' do
       # It is expected to fail as number of stripes cannot be changed on a existing logical volume
-      apply_manifest(pp1, { expect_failures: true, debug: true })
+      apply_manifest(pp1, expect_failures: true)
       remove_all(pv, vg, lv)
     end
   end

--- a/spec/acceptance/create_filesystem_spec.rb
+++ b/spec/acceptance/create_filesystem_spec.rb
@@ -91,7 +91,7 @@ describe 'create filesystems' do
     end
   end
 
-  describe 'create_filesystem_with_ensure_property_ext4' do
+  describe 'create_filesystem_with_ensure_property_ext4 & check stripes change' do
     let(:pv) do
       "/dev/#{device_name}"
     end
@@ -116,6 +116,7 @@ describe 'create filesystems' do
           ensure        => present,
           volume_group  => '#{vg}',
           size          => '20M',
+          stripes       => 1,
         }
         ->
         filesystem {'Create_filesystem':
@@ -126,9 +127,25 @@ describe 'create filesystems' do
       MANIFEST
     end
 
-    it 'applies the manifest' do
+    let(:pp1) do
+      <<~MANIFEST
+        logical_volume{'#{lv}':
+          ensure        => present,
+          volume_group  => '#{vg}',
+          size          => '20M',
+          stripes       => 2,
+        }
+      MANIFEST
+    end
+
+    it 'applies the manifest and creates an ext4 filesystem' do
       apply_manifest(pp)
       expect(run_shell("file -sL /dev/#{vg}/#{lv}").stdout).to match %r{ext4}
+    end
+
+    it 'change the stripes and re-applies the manifest' do
+      # It is expected to fail as number of stripes cannot be changed on a existing logical volume
+      apply_manifest(pp1, { expect_failures: true, debug: true })
       remove_all(pv, vg, lv)
     end
   end


### PR DESCRIPTION
## Summary
Adding new getters and setters for stripes.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)
