### PR TITLE
Support multiple pv's in lvm::volume

### DIFF
--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -13,7 +13,7 @@
 # @param fstype The type of filesystem to create on the logical
 # volume.
 #
-# @param pv path to physcial volume
+# @param pv path(s) to physcial volume(s)
 #
 # @param vg value of volume group
 #
@@ -36,7 +36,7 @@
 #
 define lvm::volume (
   Enum['present', 'absent', 'cleaned'] $ensure,
-  Stdlib::Absolutepath $pv,
+  Variant[Stdlib::Absolutepath, Array[Stdlib::Absolutepath]] $pv,
   String[1] $vg,
   Optional[String[1]] $fstype                     = undef,
   Optional[String[1]] $size                       = undef,

--- a/spec/defines/volume_spec.rb
+++ b/spec/defines/volume_spec.rb
@@ -5,15 +5,28 @@ require 'spec_helper'
 describe 'lvm::volume' do
   let(:title) { 'lv_example0' }
 
-  context 'when passed valid parameters, it will compile' do
-    let :params do
-      {
-        ensure: 'present',
-        vg: 'vg_example0',
-        pv: '/dev/sdd1',
-        fstype: 'ext4',
-        size: '100GB'
-      }
+  let :params do
+    {
+      ensure: 'present',
+      vg: 'vg_example0',
+      fstype: 'ext4',
+      size: '100GB'
+    }
+  end
+
+  context 'when passed with a single pv, it will compile' do
+    let(:params) do
+      super().merge({ 'pv' => '/dev/sdd1' })
+    end
+
+    it {
+      expect(subject).to compile
+    }
+  end
+
+  context 'when passed with multiple pvs, it will compile' do
+    let(:params) do
+      super().merge({ 'pv' => ['/dev/sdd1', '/dev/sde2'] })
     end
 
     it {


### PR DESCRIPTION
## Summary

Before data types were introduced in commit 83efe16, it was possible to pass an array of physical volumes to the `$lvm::volume::pv` parameter.

This commit updates the type of the pv parameter to either support a single path or an array of paths.

Spec test updated accordingly.

## Additional Context

We have a vg with 2 pv's:

```
PV         VG  Fmt  Attr PSize    PFree
/dev/sda1  myvg lvm2 a--  <100g       0
/dev/sdb1  myvg lvm2 a--  <100g       0
```

We create an lvm volume:

```
lvm::volume {
  'myvol':
    ensure => 'present',
    vg     => 'myvg',
    pv     => [
      '/dev/sda1',
      '/dev/sda2'
    ],
    fstype => 'xfs',
    size   => '10G';
}
```

When passing an array as pv, we get this error:

```
Lvm::Volume[myvol]: parameter 'pv' expects a Stdlib::Absolutepath = Variant[Stdlib::Windowspath = Pattern[/\A(([a-zA-Z]:[\\\/])|([\\\/][\\\/][^\\\/]+[\\\/][^\\\/]+)|([\\\/][\\\/]\?[\\\/][^\\\/]+)).*\z/], Stdlib::Unixpath = Pattern[/\A\/([^\n\/\0]+\/*)*\z/]] value, got Tuple
```

## Related Issues (if any)

Commit 83efe16 was merged in #283

## Checklist
- [ x ] 🟢 Spec tests.
- [ x ] Manually verified.