### PR TITLE
fix: use require_relative to require puppet_x

### DIFF
--- a/lib/facter/logical_volumes.rb
+++ b/lib/facter/logical_volumes.rb
@@ -9,7 +9,7 @@ Facter.add(:logical_volumes) do
 
   setcode do
     # Require the helper methods to reduce duplication
-    require 'puppet_x/lvm/output'
+    require_relative '../puppet_x/lvm/output'
 
     # List columns here that can be passed to the lvs -o command. Dont't
     # include things in here that might be bland as we currently can't deal

--- a/lib/facter/physical_volumes.rb
+++ b/lib/facter/physical_volumes.rb
@@ -9,7 +9,7 @@ Facter.add(:physical_volumes) do
 
   setcode do
     # Require the helper methods to reduce duplication
-    require 'puppet_x/lvm/output'
+    require_relative '../puppet_x/lvm/output'
 
     # List columns here that can be passed to the lvs -o command. Dont't
     # include things in here that might be bland as we currently can't deal

--- a/lib/facter/volume_groups.rb
+++ b/lib/facter/volume_groups.rb
@@ -9,7 +9,7 @@ Facter.add(:volume_groups) do
 
   setcode do
     # Require the helper methods to reduce duplication
-    require 'puppet_x/lvm/output'
+    require_relative '../puppet_x/lvm/output'
 
     # List columns here that can be passed to the lvs -o command. Dont't
     # include things in here that might be bland as we currently can't deal


### PR DESCRIPTION
## Summary
For some reason the require statement in the fact files the puppet lvm module seem to break facter on the command line for Debian 12 using the Puppetlabs Puppet 8 agent:
```
root@host:~# cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```
```
root@host:~# dpkg -l puppet*
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version          Architecture Description
+++-==============-================-============-======================================================================================================
ii  puppet-agent   8.10.0-1bookworm amd64        The Puppet Agent package contains all of the elements needed to run puppet, including ruby and facter.
```
```
root@host:~# apt-cache showpkg puppet-agent
Package: puppet-agent
Versions:
8.10.0-1bookworm (/var/lib/apt/lists/apt.puppetlabs.com_dists_bookworm_puppet8_binary-amd64_Packages) (/var/lib/dpkg/status)
 Description Language:
                 File: /var/lib/apt/lists/apt.puppetlabs.com_dists_bookworm_puppet8_binary-amd64_Packages
                  MD5: 3257ba9e4ae8f8ce80c1c56477d503be
...
```
```
root@host:~# facter volume_groups
/opt/puppetlabs/puppet/cache/lib/facter/volume_groups.rb:13:in `require_relative': cannot load such file -- /opt/puppetlabs/puppet/cache/puppet_x/lvm/output (LoadError)
        from /opt/puppetlabs/puppet/cache/lib/facter/volume_groups.rb:13:in `block (2 levels) in <top (required)>'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/custom_facts/util/resolution.rb:193:in `resolve_value'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/custom_facts/core/resolvable.rb:78:in `block (2 levels) in value'
        from /opt/puppetlabs/puppet/lib/ruby/3.2.0/timeout.rb:173:in `timeout'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/custom_facts/core/resolvable.rb:77:in `block in value'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/custom_facts/core/resolvable.rb:102:in `with_timing'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/custom_facts/core/resolvable.rb:76:in `value'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/custom_facts/util/fact.rb:213:in `block in find_first_real_value'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/custom_facts/util/fact.rb:211:in `each'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/custom_facts/util/fact.rb:211:in `find_first_real_value'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/custom_facts/util/fact.rb:133:in `block (2 levels) in value'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/framework/benchmarking/timer.rb:18:in `measure'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/custom_facts/util/fact.rb:132:in `block in value'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/custom_facts/util/fact.rb:179:in `searching'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/custom_facts/util/fact.rb:129:in `value'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/framework/core/fact/external/external_fact_manager.rb:21:in `block in external_facts'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/framework/core/fact/external/external_fact_manager.rb:19:in `each'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/framework/core/fact/external/external_fact_manager.rb:19:in `external_facts'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/framework/core/fact/external/external_fact_manager.rb:7:in `resolve_facts'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/framework/core/fact_manager.rb:24:in `resolve_facts'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter.rb:530:in `resolve_facts_for_user_query'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter.rb:461:in `to_user_output'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/framework/cli/cli.rb:124:in `query'
        from /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/command.rb:27:in `run'
        from /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/invocation.rb:127:in `invoke_command'
        from /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor.rb:392:in `dispatch'
        from /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/base.rb:485:in `start'
        from /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/framework/cli/cli_launcher.rb:23:in `start'
        from /opt/puppetlabs/puppet/bin/facter:10:in `<main>'
```

Using `require_relative '../puppet_x/lvm/output'` instead of `require 'puppet_x/lvm/output'` seems to fix the issue for the command line facter:
```
root@host:~# facter volume_groups
{
  vgsystem => {
    allocation_policy => "normal",
    attr => "wz--n-",
    free => "<33.61g",
    permissions => "writeable",
    size => "<63.75g",
    uuid => "L7qkAs-MvY6-yNWr-TQr1-FPpU-lqz8-rsL4cf"
  }
}
```