### PR TITLE
logical_volume: Add option to use dm device-path for mountpoint

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -108,6 +108,7 @@ The following parameters are available in the `lvm::logical_volume` defined type
 * [`dump`](#-lvm--logical_volume--dump)
 * [`fs_type`](#-lvm--logical_volume--fs_type)
 * [`mkfs_options`](#-lvm--logical_volume--mkfs_options)
+* [`use_dm_devicepath`](#-lvm--logical_volume--use_dm_devicepath)
 * [`mountpath`](#-lvm--logical_volume--mountpath)
 * [`mountpath_require`](#-lvm--logical_volume--mountpath_require)
 * [`mounted`](#-lvm--logical_volume--mounted)
@@ -197,6 +198,14 @@ Data type: `Optional[String[1]]`
 
 
 Default value: `undef`
+
+##### <a name="-lvm--logical_volume--use_dm_devicepath"></a>`use_dm_devicepath`
+
+Data type: `Boolean`
+
+Whetever to use the default /dev/$vg/$lv as device name or use /dev/mapper/$vg-$lv for mount and filesystem creation.
+
+Default value: `false`
 
 ##### <a name="-lvm--logical_volume--mountpath"></a>`mountpath`
 


### PR DESCRIPTION
logical_volume: Add option use_dm_devicepath to use /dev/mapper/$vg-$lv instead of /dev/$vg/$lv

## Summary
We have the requirement to use /dev/mapper entries in /etc/fstab, currently when using the lvm::logical_volume entries will always be /dev/$vg/$lv.
To allow creation of entries with the /dev/mapper entries, an additional option use_dm_devicepath is introduced. The default value is set to keep the previous/default behavior.

From previous PRs (!124, !153, !199) it seems other have (or had) the requirement too, but it the PRs where never finalized from the PR openers.

## Related Issues
- https://github.com/puppetlabs/puppetlabs-lvm/pull/124
- https://github.com/puppetlabs/puppetlabs-lvm/pull/153
- https://github.com/puppetlabs/puppetlabs-lvm/pull/199

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)
