### PR TITLE
ci(MODULES-11557): add Twingate setup step to GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,13 @@ jobs:
     env:
       PUPPET_GEM_VERSION: '~> 7.24'
       FACTER_GEM_VERSION: 'https://github.com/puppetlabs/facter#main'  # why is this set?
+      TWINGATE_PUBLIC_REPO_KEY: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
 
     steps:
+      - name: "Install Twingate"
+        uses: "twingate/github-action@v1"
+        with:
+          service-key: ${{ env.TWINGATE_PUBLIC_REPO_KEY }}
 
       - name: "Checkout"
         uses: "actions/checkout@v3"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,8 +45,13 @@ jobs:
     env:
       PUPPET_GEM_VERSION: '~> 7.24'
       FACTER_GEM_VERSION: 'https://github.com/puppetlabs/facter#main'  # why is this set?
+      TWINGATE_PUBLIC_REPO_KEY: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
 
     steps:
+      - name: "Install Twingate"
+        uses: "twingate/github-action@v1"
+        with:
+          service-key: ${{ env.TWINGATE_PUBLIC_REPO_KEY }}
 
       - name: "Checkout"
         uses: "actions/checkout@v3"


### PR DESCRIPTION
## Summary
Adds the Twingate installation step in `.github/workflows/...` using `twingate/github-action@v1`. The action uses the `${{ secrets.TWINGATE_KEY }}` to establish secure access to internal resources.

This enables the workflow to access protected infrastructure during CI runs.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)
