### PR TITLE
(MODULES-11788) Pass converted boolean parameter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+**Setup:**
+```bash
+bundle install
+bundle exec rake spec_prep   # Install fixture modules (required before running specs)
+```
+
+**Tests:**
+```bash
+bundle exec rake spec                    # Run all unit tests
+bundle exec rspec spec/unit/puppet/provider/logical_volume/lvm_spec.rb  # Run a single spec file
+bundle exec rspec spec/unit/puppet/provider/logical_volume/lvm_spec.rb:42  # Run a specific example
+```
+
+**Linting and validation:**
+```bash
+bundle exec rake lint        # puppet-lint (configured via .puppet-lint.rc)
+bundle exec rake rubocop     # RuboCop Ruby style checks
+bundle exec rake validate    # Syntax check Ruby, Puppet manifests, and metadata
+bundle exec rake syntax      # Puppet manifest and Hiera syntax check
+```
+
+**All checks (pre-release):**
+```bash
+bundle exec rake release_checks
+```
+
+## Architecture
+
+This is a Puppet module that manages Linux LVM and AIX logical volume resources. It follows standard Puppet module structure.
+
+### Resource type dependency chain
+
+```
+filesystem -> logical_volume -> volume_group -> physical_volume(s)
+```
+
+Each layer must be defined before the one above it. The `lvm::volume` defined type in `manifests/volume.pp` wraps this full chain for the common single-PV case.
+
+### Types and providers (`lib/puppet/`)
+
+Each of the four resource types (`logical_volume`, `volume_group`, `physical_volume`, `filesystem`) has:
+- A **type** definition in `lib/puppet/type/` — declares parameters, properties, validation, and `autorequire` relationships
+- A **Linux provider** (`lvm`) in `lib/puppet/provider/<type>/lvm.rb` — wraps LVM CLI commands (`lvcreate`, `lvextend`, `vgcreate`, etc.)
+- An **AIX provider** (`aix`) in `lib/puppet/provider/<type>/aix.rb` — wraps AIX-specific commands; uses `defaultfor`/`confine` on `os.name: :AIX`
+
+The Linux providers use `commands` to declare required binaries (e.g., `lvcreate`, `lvremove`) and `optional_commands` for optional ones (e.g., `xfs_growfs`, `resize4fs`). Puppet raises an error at catalog application time if a required command is missing.
+
+### Boolean parameter pattern
+
+Many boolean parameters accept `[:true, true, 'true', :false, false, 'false']` to handle Puppet's symbol-vs-string boolean ambiguity. When passing these values to shell commands, convert explicitly — e.g., `[:true, true, 'true'].include?(value) ? 'y' : 'n'`.
+
+### Facter facts (`lib/facter/`)
+
+Four custom facts: `lvm_support`, `logical_volumes`, `physical_volumes`, `volume_groups`. These are used internally and in manifests; some flat `lvm_vg_*` / `lvm_pv_*` facts are deprecated in favour of structured facts.
+
+### Puppet functions (`functions/`)
+
+- `lvm::bytes_to_size` — converts bytes integer to human-readable size string
+- `lvm::size_to_bytes` — converts size string (e.g. `"20G"`) to bytes
+
+### Helper (`lib/puppet_x/lvm/output.rb`)
+
+`Puppet_X::LVM::Output.parse` parses columnar LVM CLI output (e.g. `lvs`, `vgs`) into a hash, stripping column name prefixes (e.g., `lv_name` → `name`).
+
+### Manifests (`manifests/`)
+
+- `lvm` class — optional `lvm2` package management + iterates `$volume_groups` hash via `create_resources`
+- `lvm::volume` defined type — convenience wrapper for the full PV→VG→LV→FS chain
+- `lvm::volume_group` / `lvm::logical_volume` / `lvm::physical_volume` — defined types iterated from the `lvm` class hash
+
+### Tasks (`tasks/`)
+
+Bolt tasks for imperative operations: `ensure_pv`, `ensure_vg`, `ensure_lv`, `ensure_fs`, `extend_lv`, `extend_vg`, `mount_lv`. Each task has a `.rb` implementation and a `.json` parameter schema.
+
+### Plans (`plans/`)
+
+`lvm::expand` — Bolt plan for expanding an LV and its filesystem.
+
+### Test structure (`spec/`)
+
+- `spec/unit/puppet/provider/<type>/` — provider unit tests using Mocha stubs (`stub_everything`, `stubs`, `expects`)
+- `spec/unit/puppet/type/` — type unit tests
+- `spec/unit/facter/` — fact unit tests
+- `spec/acceptance/` — Litmus acceptance tests (require provisioned targets)
+- `spec/lib/helpers.rb`, `spec/lib/matchers.rb` — shared test helpers

--- a/lib/puppet/provider/filesystem/aix.rb
+++ b/lib/puppet/provider/filesystem/aix.rb
@@ -74,7 +74,7 @@ Puppet::Type.type(:filesystem).provide :aix do
     args.each do |arg|
       if @resource[arg]
         ans = parse_boolean(@resource[arg])
-        attr_args.push('-a', "#{attribute_flag(arg)}=#{@resource[arg]}")
+        attr_args.push('-a', "#{attribute_flag(arg)}=#{ans}")
       end
     end
     attr_args

--- a/spec/unit/puppet/provider/filesystem/aix_spec.rb
+++ b/spec/unit/puppet/provider/filesystem/aix_spec.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:filesystem).provider(:aix)
+
+describe provider_class do
+  let(:resource) { Puppet::Type.type(:filesystem).new(name: '/mnt/data') }
+  let(:provider) { provider_class.new(resource) }
+
+  describe '#exists?' do
+    it 'returns true when lsfs exits successfully' do
+      status = stub('status', success?: true)
+      Open3.expects(:popen3).with('lsfs /mnt/data').returns([nil, nil, nil, stub('thread', value: status)])
+      expect(provider.exists?).to be true
+    end
+
+    it 'returns false when lsfs exits with a non-zero status' do
+      status = stub('status', success?: false)
+      Open3.expects(:popen3).with('lsfs /mnt/data').returns([nil, nil, nil, stub('thread', value: status)])
+      expect(provider.exists?).to be false
+    end
+  end
+
+  describe '#create' do
+    it 'passes fs_type and mount point to crfs' do
+      resource[:fs_type] = 'jfs2'
+      provider.expects(:crfs).with('-v', 'jfs2', '-m', '/mnt/data')
+      provider.create
+    end
+
+    it 'maps ag_size to the crfs -a ag flag' do
+      resource[:ag_size] = '8'
+      provider.expects(:crfs).with('-a', 'ag=8', '-m', '/mnt/data')
+      provider.create
+    end
+
+    it 'converts :true attribute values to "yes"' do
+      pending('MODULES-11788')
+      # large_files has no entry in attribute_flag's rename map (only large_file does),
+      # so the attribute name passes through as-is: "-a large_files=yes"
+      resource[:large_files] = :true
+      provider.expects(:crfs).with('-a', 'large_files=yes', '-m', '/mnt/data')
+      provider.create
+    end
+
+    it 'converts :false attribute values to "no"' do
+      pending('MODULES-11788')
+      resource[:mountguard] = :false
+      provider.expects(:crfs).with('-a', 'mountguard=no', '-m', '/mnt/data')
+      provider.create
+    end
+
+    it 'passes volume_group as the -g flag' do
+      resource[:volume_group] = 'myvg'
+      provider.expects(:crfs).with('-m', '/mnt/data', '-g', 'myvg')
+      provider.create
+    end
+
+    it 'passes atboot as the -A flag, converting :true to "yes"' do
+      resource[:atboot] = :true
+      provider.expects(:crfs).with('-m', '/mnt/data', '-A', 'yes')
+      provider.create
+    end
+
+    context 'when size is set and already matches the current filesystem size' do
+      it 'does not call size= after crfs' do
+        resource[:size] = '1G'
+        provider.stubs(:size).returns('1G')
+        provider.expects(:crfs).with('-a', 'size=1G', '-m', '/mnt/data')
+        provider.expects(:size=).never
+        provider.create
+      end
+    end
+
+    context 'when size is set but does not match the current filesystem size' do
+      it 'calls size= after crfs to sync the filesystem' do
+        resource[:size] = '2G'
+        provider.stubs(:size).returns('1G')
+        provider.expects(:crfs).with('-a', 'size=2G', '-m', '/mnt/data')
+        provider.expects(:size=).with('2G')
+        provider.create
+      end
+    end
+  end
+
+  describe '#size=' do
+    it 'calls chfs with the size attribute and mount point' do
+      resource[:size] = '2G'
+      provider.expects(:chfs).with('-a', 'size=2G', '/mnt/data')
+      provider.size = '2G'
+    end
+  end
+
+  describe '#size' do
+    # lsfs -q output columns (whitespace-separated):
+    #   Name  Nodename  MountPt  VFS  Size  Options  Auto  Accounting
+    # The provider matches elements[2] against @resource[:name] and reads elements[4] as blocks.
+
+    before(:each) do
+      resource[:size] = '1G'
+      provider.stubs(:pp_size).returns(4) # ppsize = 4 * 1024 * 2 = 8192 blocks
+    end
+
+    it 'returns the resource size when the reported block count matches' do
+      # 1G = 2_097_152 blocks; blk_roundup(2_097_152) with ppsize=8192 stays 2_097_152
+      lsfs_line = "/dev/myvg/mylv  --  /mnt/data  jfs2  2097152  rw  yes  no\n"
+      Open3.expects(:popen3).with('lsfs -q /mnt/data').yields(nil, [lsfs_line], nil)
+      expect(provider.size).to eq('1G')
+    end
+
+    it 'returns the current size when the reported block count differs from requested' do
+      # 3G = 6_291_456 blocks; blk_to_val(6_291_456, 'G') = '3G'
+      lsfs_line = "/dev/myvg/mylv  --  /mnt/data  jfs2  6291456  rw  yes  no\n"
+      Open3.expects(:popen3).with('lsfs -q /mnt/data').yields(nil, [lsfs_line], nil)
+      expect(provider.size).to eq('3G')
+    end
+
+    it 'returns "0G" when no lsfs line matches the mount point' do
+      lsfs_line = "/dev/other/lv  --  /mnt/other  jfs2  2097152  rw  yes  no\n"
+      Open3.expects(:popen3).with('lsfs -q /mnt/data').yields(nil, [lsfs_line], nil)
+      expect(provider.size).to eq('0G')
+    end
+  end
+
+  describe '#parse_boolean' do
+    it 'converts :true to "yes"' do
+      expect(provider.parse_boolean(:true)).to eq('yes')
+    end
+
+    it 'converts :false to "no"' do
+      expect(provider.parse_boolean(:false)).to eq('no')
+    end
+
+    it 'passes through non-boolean values unchanged' do
+      expect(provider.parse_boolean('jfs2')).to eq('jfs2')
+    end
+  end
+
+  describe '#val_to_blk' do
+    it 'converts megabytes to 512-byte blocks' do
+      expect(provider.val_to_blk('4M')).to eq(8192)
+    end
+
+    it 'converts gigabytes to 512-byte blocks' do
+      expect(provider.val_to_blk('2G')).to eq(4_194_304)
+    end
+
+    it 'returns the integer value for bare numbers (no unit suffix)' do
+      expect(provider.val_to_blk('512')).to eq(512)
+    end
+  end
+
+  describe '#blk_to_val' do
+    it 'converts 512-byte blocks to megabytes' do
+      expect(provider.blk_to_val(8192, 'M')).to eq('4M')
+    end
+
+    it 'converts 512-byte blocks to gigabytes' do
+      expect(provider.blk_to_val(2_097_152, 'G')).to eq('1G')
+    end
+
+    it 'returns the raw block count when no unit is given' do
+      expect(provider.blk_to_val(512)).to eq(512)
+    end
+  end
+
+  describe '#blk_roundup' do
+    before(:each) { provider.stubs(:pp_size).returns(4) } # ppsize = 4 * 1024 * 2 = 8192 blocks
+
+    it 'returns the block count unchanged when already aligned to a PP boundary' do
+      expect(provider.blk_roundup(8192)).to eq(8192)
+    end
+
+    it 'rounds up to the next PP boundary' do
+      expect(provider.blk_roundup(8193)).to eq(16_384)
+    end
+  end
+
+  describe '#pp_size' do
+    it 'queries lsvg for the volume_group and returns the PP size in MB' do
+      resource[:volume_group] = 'myvg'
+      # `lsvg myvg | grep 'PP SIZE'` returns one line; split on whitespace gives index 5 as the number
+      lsvg_line = "VG STATE:         active         PP SIZE:         4 megabyte(s)\n"
+      Open3.expects(:capture2).with("lsvg myvg | /bin/grep 'PP SIZE'").returns([lsvg_line, nil])
+      expect(provider.pp_size).to eq(4)
+    end
+
+    it 'defaults to rootvg when volume_group is not set' do
+      lsvg_line = "VG STATE:         active         PP SIZE:         8 megabyte(s)\n"
+      Open3.expects(:capture2).with("lsvg rootvg | /bin/grep 'PP SIZE'").returns([lsvg_line, nil])
+      expect(provider.pp_size).to eq(8)
+    end
+  end
+end

--- a/spec/unit/puppet/provider/filesystem/aix_spec.rb
+++ b/spec/unit/puppet/provider/filesystem/aix_spec.rb
@@ -36,7 +36,6 @@ describe provider_class do
     end
 
     it 'converts :true attribute values to "yes"' do
-      pending('MODULES-11788')
       # large_files has no entry in attribute_flag's rename map (only large_file does),
       # so the attribute name passes through as-is: "-a large_files=yes"
       resource[:large_files] = :true
@@ -45,7 +44,6 @@ describe provider_class do
     end
 
     it 'converts :false attribute values to "no"' do
-      pending('MODULES-11788')
       resource[:mountguard] = :false
       provider.expects(:crfs).with('-a', 'mountguard=no', '-m', '/mnt/data')
       provider.create


### PR DESCRIPTION
## Summary

Previously, we converted true/false to yes/no, but passed the original value to
the crfs command, resulting in

    crfs: 0507-587 Invalid value for isnapshot option specified, true.

Adds missing tests and CLAUDE.md

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)


### Before
```puppet
filesystem { '/mnt/test':
  ensure       => present,
  fs_type      => 'jfs2',
  volume_group => 'rootvg',
  size         => '32M',
  isnapshot    => false,
  atboot       => false,
}
```

```
# /opt/puppetlabs/puppet/bin/puppet apply --debug manifest.pp
...
Debug: Executing: '/usr/sbin/crfs -a size=32M -a isnapshot=false -v jfs2 -m /mnt/test -g rootvg -A no'
Error: Execution of '/usr/sbin/crfs -a size=32M -a isnapshot=false -v jfs2 -m /mnt/test -g rootvg -A no' returned 1: crfs: 0507-587 Invalid value for isnapshot option specified, false.
        Valid values for the isnapshot option: yes, no
Error: /Stage[main]/Main/Filesystem[/mnt/test]/ensure: change from 'absent' to 'present' failed: Execution of '/usr/sbin/crfs -a size=32M -a isnapshot=false -v jfs2 -m /mnt/test -g rootvg -A no' returned 1: crfs: 0507-587 Invalid value for isnapshot option specified, false.
        Valid values for the isnapshot option: yes, no
```

### After

```
# /opt/puppetlabs/puppet/bin/puppet apply --debug manifest.pp
...
Debug: Executing: '/usr/sbin/crfs -a size=32M -a isnapshot=no -v jfs2 -m /mnt/test -g rootvg -A no'
Notice: /Stage[main]/Main/Filesystem[/mnt/test]/ensure: created
```

Also

```
# /opt/puppetlabs/puppet/bin/puppet resource filesystem --debug /mnt/test ensure=present fs_type=jfs2 volume_group=rootvg size=32M isnapshot=true atboot=false
...
Debug: Executing: '/usr/sbin/crfs -a size=32M -a isnapshot=yes -v jfs2 -m /mnt/test -g rootvg -A no'
Notice: /Filesystem[/mnt/test]/ensure: created
```