### PR TITLE
(CAT-2665) Roll out safe fork CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,26 @@ on:
   pull_request:
     branches:
       - "main"
+  pull_request_target:
+    types: [labeled, reopened]
+    branches:
+      - "main"
   workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   PUPPET_FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
   BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: "forge-key:${{ secrets.PUPPET_FORGE_TOKEN_PUBLIC }}"
-    
+
 jobs:
   Spec:
+    if: github.event_name != 'pull_request_target'
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
     with:
       runs_on: "ubuntu-24.04"
@@ -19,11 +31,14 @@ jobs:
 
   setup_matrix:
     name: "Setup Test Matrix"
-    needs: Spec
     runs-on: "ubuntu-24.04"
+    # For pull_request_target (fork PRs), only run once the allowed-for-ci label is present.
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      contains(github.event.pull_request.labels.*.name, 'allowed-for-ci')
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
-    
+
     env:
       BUNDLE_WITHOUT: release_prep
 
@@ -44,14 +59,38 @@ jobs:
         run: |
           bundle exec matrix_from_metadata_v3 --provision-prefer provision_service --nightly --platform-exclude scientific-7 --platform-exclude ubuntu-18.04 --platform-exclude ubuntu-20.04
 
+  approval_gate:
+    name: "Fork PR approval gate"
+    needs: setup_matrix
+    runs-on: ubuntu-latest
+    # Funnels the puppetcore-fork environment approval through a single non-matrix job.
+    # Same-repo PRs and workflow_dispatch skip this; Acceptance handles the skipped case
+    # via always() below.
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.fork == true
+    environment: puppetcore-fork
+    steps:
+      - name: "Approval received"
+        run: |
+          echo "Approved fork PR #${{ github.event.pull_request.number }}"
+          echo "Head SHA at approval: ${{ github.event.pull_request.head.sha }}"
+
   Acceptance:
     name: "Acceptance tests (${{matrix.platforms.label}}, ${{matrix.collection.collection || matrix.collection}})"
-    needs: setup_matrix
+    needs: [setup_matrix, approval_gate]
     runs-on: ubuntu-latest
     timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.setup_matrix.outputs.matrix)}}
+    # always() is required so this is evaluated when approval_gate is skipped
+    # (non-fork events); without it, dependency-skip would cascade.
+    if: >-
+      always() &&
+      needs.setup_matrix.result == 'success' &&
+      (needs.approval_gate.result == 'success' ||
+       needs.approval_gate.result == 'skipped')
 
     env:
       BUNDLE_WITHOUT: release_prep

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
     # For pull_request_target (fork PRs), only run once the allowed-for-ci label is present.
     if: >-
       github.event_name != 'pull_request_target' ||
+      github.event.pull_request.head.repo.fork != true ||
       contains(github.event.pull_request.labels.*.name, 'allowed-for-ci')
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
@@ -47,6 +48,7 @@ jobs:
         uses: "actions/checkout@v4"
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: "Setup ruby"
         uses: "ruby/setup-ruby@v1"
@@ -126,6 +128,7 @@ jobs:
         uses: "actions/checkout@v4"
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: "Setup ruby"
         uses: "ruby/setup-ruby@v1"

--- a/.github/workflows/fork_ci_label_guard.yml
+++ b/.github/workflows/fork_ci_label_guard.yml
@@ -1,0 +1,12 @@
+name: "Fork CI Label Guard"
+
+on:
+  pull_request_target:
+    types: [synchronize, closed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  strip:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/fork_ci_label_guard.yml@main"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,10 @@
 ---
-require:
+plugins:
 - rubocop-performance
 - rubocop-rspec
+- rubocop-rspec_rails
+- rubocop-factory_bot
+- rubocop-capybara
 AllCops:
   NewCops: enable
   DisplayCopNames: true
@@ -107,6 +110,8 @@ Performance/StringInclude:
   Enabled: true
 Performance/Sum:
   Enabled: true
+Security/IoMethods:
+  Enabled: true
 Style/CollectionMethods:
   Enabled: true
 Style/MethodCalledOnDoEndBlock:
@@ -120,6 +125,12 @@ Bundler/InsecureProtocolSource:
 Capybara/CurrentPathExpectation:
   Enabled: false
 Capybara/VisibilityMatcher:
+  Enabled: false
+FactoryBot/AttributeDefinedStatically:
+  Enabled: false
+FactoryBot/CreateList:
+  Enabled: false
+FactoryBot/FactoryClassName:
   Enabled: false
 Gemspec/DuplicatedAssignment:
   Enabled: false
@@ -295,8 +306,6 @@ Performance/UriDefaultParser:
   Enabled: false
 RSpec/Be:
   Enabled: false
-RSpec/Capybara/FeatureMethods:
-  Enabled: false
 RSpec/ContainExactly:
   Enabled: false
 RSpec/ContextMethod:
@@ -304,6 +313,8 @@ RSpec/ContextMethod:
 RSpec/ContextWording:
   Enabled: false
 RSpec/DescribeClass:
+  Enabled: false
+RSpec/Dialect:
   Enabled: false
 RSpec/EmptyHook:
   Enabled: false
@@ -320,12 +331,6 @@ RSpec/ExampleWithoutDescription:
 RSpec/ExpectChange:
   Enabled: false
 RSpec/ExpectInHook:
-  Enabled: false
-RSpec/FactoryBot/AttributeDefinedStatically:
-  Enabled: false
-RSpec/FactoryBot/CreateList:
-  Enabled: false
-RSpec/FactoryBot/FactoryClassName:
   Enabled: false
 RSpec/HooksBeforeExamples:
   Enabled: false
@@ -374,8 +379,6 @@ RSpec/VariableDefinition:
 RSpec/VoidExpect:
   Enabled: false
 RSpec/Yield:
-  Enabled: false
-Security/Open:
   Enabled: false
 Style/AccessModifierDeclarations:
   Enabled: false
@@ -501,6 +504,12 @@ Capybara/SpecificFinders:
   Enabled: false
 Capybara/SpecificMatcher:
   Enabled: false
+FactoryBot/ConsistentParenthesesStyle:
+  Enabled: false
+FactoryBot/FactoryNameStyle:
+  Enabled: false
+FactoryBot/SyntaxMethods:
+  Enabled: false
 Gemspec/DeprecatedAttributeAssignment:
   Enabled: false
 Gemspec/DevelopmentDependencies:
@@ -601,27 +610,11 @@ RSpec/DuplicatedMetadata:
   Enabled: false
 RSpec/ExcessiveDocstringSpacing:
   Enabled: false
-RSpec/FactoryBot/ConsistentParenthesesStyle:
-  Enabled: false
-RSpec/FactoryBot/FactoryNameStyle:
-  Enabled: false
-RSpec/FactoryBot/SyntaxMethods:
-  Enabled: false
 RSpec/IdenticalEqualityAssertion:
   Enabled: false
 RSpec/NoExpectationExample:
   Enabled: false
 RSpec/PendingWithoutReason:
-  Enabled: false
-RSpec/Rails/AvoidSetupHook:
-  Enabled: false
-RSpec/Rails/HaveHttpStatus:
-  Enabled: false
-RSpec/Rails/InferredSpecType:
-  Enabled: false
-RSpec/Rails/MinitestAssertions:
-  Enabled: false
-RSpec/Rails/TravelAround:
   Enabled: false
 RSpec/RedundantAround:
   Enabled: false
@@ -633,9 +626,17 @@ RSpec/SubjectDeclaration:
   Enabled: false
 RSpec/VerifiedDoubleReference:
   Enabled: false
-Security/CompoundHash:
+RSpecRails/AvoidSetupHook:
   Enabled: false
-Security/IoMethods:
+RSpecRails/HaveHttpStatus:
+  Enabled: false
+RSpecRails/InferredSpecType:
+  Enabled: false
+RSpecRails/MinitestAssertions:
+  Enabled: false
+RSpecRails/TravelAround:
+  Enabled: false
+Security/CompoundHash:
   Enabled: false
 Style/ArgumentsForwarding:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -37,9 +37,16 @@ Naming/ClassAndModuleCamelCase:
     - 'lib/puppet_x/lvm/output.rb'
 
 # Offense count: 1
-# Configuration parameters: Include, CustomTransform, IgnoreMethods, SpecSuffixOnly.
+# Configuration parameters: Include, CustomTransform, IgnoreMethods.
 # Include: **/*_spec*rb*, **/spec/**/*
-RSpec/FilePath:
+RSpec/SpecFilePathFormat:
+  Exclude:
+    - 'spec/unit/type/physical_volume.rb'
+
+# Offense count: 1
+# Configuration parameters: Include, CustomTransform, IgnoreMethods.
+# Include: **/*_spec*rb*, **/spec/**/*
+RSpec/SpecFilePathSuffix:
   Exclude:
     - 'spec/unit/type/physical_volume.rb'
 

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ end
 group :development do
   gem "json", '= 2.6.1',                         require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.18.0',                        require: false if Gem::Requirement.create(['>= 4.0.0', '< 5.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "deep_merge", '~> 1.2.2',                  require: false
   gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
@@ -52,29 +53,34 @@ group :development do
   gem "pry", '~> 0.10',                          require: false
   gem "simplecov-console", '~> 0.9',             require: false
   gem "puppet-debugger", '~> 1.6',               require: false
-  gem "rubocop", '~> 1.50.0',                    require: false
-  gem "rubocop-performance", '= 1.16.0',         require: false
-  gem "rubocop-rspec", '= 2.19.0',               require: false
-  gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "bigdecimal", '< 3.2.2',                   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "rubocop", '~> 1.73.0',                    require: false
+  gem "rubocop-performance", '~> 1.24.0',        require: false
+  gem "rubocop-rspec", '~> 3.5.0',               require: false
+  gem "rubocop-rspec_rails", '~> 2.31.0',        require: false
+  gem "rubocop-factory_bot", '~> 2.27.0',        require: false
+  gem "rubocop-capybara", '~> 2.22.0',           require: false
+  gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:windows]
+  gem "bigdecimal", '< 3.2.2',                   require: false, platforms: [:windows]
 end
 group :development, :release_prep do
-  gem "puppet-strings", '~> 4.0',         require: false
-  gem "puppetlabs_spec_helper", '~> 8.0', require: false
-  gem "puppet-blacksmith", '~> 7.0',      require: false
+  gem "puppet-strings", '~> 4.0',              require: false
+  gem "puppetlabs_spec_helper", '~> 8.0',      require: false
+  gem "puppet-blacksmith", '>= 7.0', '< 10.0', require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '~> 2.0',   require: false, platforms: [:ruby, :x64_mingw] if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
-  gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw] if ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
-  gem "CFPropertyList", '< 3.0.7', require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet_litmus", '~> 2.5',   require: false
+  gem "faraday", '~> 2.5',         require: false
+  gem "CFPropertyList", '< 3.0.7', require: false if RUBY_PLATFORM.include?('darwin')
   gem "serverspec", '~> 2.41',     require: false
 end
 
 gems = {}
+bolt_version = ENV.fetch('BOLT_GEM_VERSION', nil)
 puppet_version = ENV.fetch('PUPPET_GEM_VERSION', nil)
 facter_version = ENV.fetch('FACTER_GEM_VERSION', nil)
 hiera_version = ENV.fetch('HIERA_GEM_VERSION', nil)
 
+gems['bolt'] = location_for(bolt_version, nil, { source: gemsource_puppetcore })
 gems['puppet'] = location_for(puppet_version, nil, { source: gemsource_puppetcore })
 gems['facter'] = location_for(facter_version, nil, { source: gemsource_puppetcore })
 gems['hiera'] = location_for(hiera_version, nil, {}) if hiera_version

--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -192,7 +192,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
 
       lvextend('-L', new_size, path, *args) || raise("Cannot extend to size #{new_size} because lvextend failed.")
 
-      unless @resource[:resize_fs] == :false || @resource[:resize_fs] == false || @resource[:resize_fs] == 'false'
+      unless [:false, false, 'false'].include?(@resource[:resize_fs])
         begin
           blkid_type = blkid(path)
           if command(:resize4fs) && blkid_type =~ %r{\bTYPE="(ext4)"}
@@ -214,8 +214,8 @@ Puppet::Type.type(:logical_volume).provide :lvm do
       end
 
     else
-      unless @resource[:size_is_minsize] == :true || @resource[:size_is_minsize] == true || @resource[:size_is_minsize] == 'true'
-        raise(Puppet::Error, "Decreasing the size requires manual intervention (#{new_size} < #{current_size})")
+      unless [:true, true, 'true'].include?(@resource[:size_is_minsize])
+        raise Puppet::Error, "Decreasing the size requires manual intervention (#{new_size} < #{current_size})"
       end
 
       info("Logical volume already has minimum size of #{new_size} (currently #{current_size})")
@@ -236,7 +236,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
 
     # Changing stripes is not supported for existing logical volumes
     return unless new_stripes_count.to_i != current_stripes
-    raise(Puppet::Error, "Changing stripes from #{current_stripes} to #{new_stripes_count} is not supported for existing logical volumes")
+    raise Puppet::Error, "Changing stripes from #{current_stripes} to #{new_stripes_count} is not supported for existing logical volumes"
   end
 
   # Look up the current number of mirrors (0=no mirroring, 1=1 spare, 2=2 spares....). Return the number as string.

--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -269,8 +269,8 @@ Puppet::Type.type(:logical_volume).provide :lvm do
 
   # Location of the mirror log. Empty string if mirror==0, else "mirrored", "disk" or "core".
   def mirrorlog
-    vgname = (@resource[:volume_group]).to_s
-    lvname = (@resource[:name]).to_s
+    vgname = @resource[:volume_group].to_s
+    lvname = @resource[:name].to_s
     raw = lvs('-a', '-o', '+devices', vgpath)
 
     if mirror.to_i.positive?

--- a/metadata.json
+++ b/metadata.json
@@ -58,7 +58,7 @@
       "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ],
-  "pdk-version": "3.5.0",
+  "pdk-version": "3.7.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates#main",
-  "template-ref": "heads/main-0-g19976cd"
+  "template-ref": "heads/main-0-g6420755"
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rspec'
-
 RSpec.configure do |c|
   c.mock_with :mocha
 end
@@ -28,7 +26,7 @@ default_fact_files.each do |f|
 
   begin
     require 'deep_merge'
-    default_facts.deep_merge!(YAML.safe_load(File.read(f), permitted_classes: [], permitted_symbols: [], aliases: true))
+    default_facts.deep_merge!(YAML.safe_load_file(f, permitted_classes: [], permitted_symbols: [], aliases: true))
   rescue StandardError => e
     RSpec.configuration.reporter.message "WARNING: Unable to load #{f}: #{e}"
   end


### PR DESCRIPTION
## Summary

- Adds `pull_request_target` trigger, `permissions`, and `concurrency` group to `ci.yml`
- Guards `Spec` against `pull_request_target` events
- Removes `needs: Spec` from `setup_matrix` (required so the acceptance path can run independently on `pull_request_target` where Spec doesn't run) and adds a fork label guard condition
- Adds `approval_gate` job with `environment: puppetcore-fork` to funnel manual approval for fork PRs through a single non-matrix job, avoiding N deployment notifications per matrix entry
- Wires `Acceptance` to `needs: [setup_matrix, approval_gate]` with `always()` so it still runs when `approval_gate` is skipped on non-fork events
- Adds `fork_ci_label_guard.yml` via `pdk update` (template `19976cd` → `6420755`)
- Routine pdk-template bumps: rubocop plugin updates, Gemfile dependency updates, `spec_helper.rb` YAML method update

## Notes

This module's `ci.yml` is fully inlined (not using `module_acceptance.yml`) so the fork CI guard pattern from `module_acceptance.yml` was replicated directly. All platform exclusion flags and custom steps (Twingate, GCP auth, DNS fix, etc.) are preserved unchanged.

## Test plan

- [x] Spec and Acceptance pass on this PR (non-fork path, `approval_gate` skipped)
- [x] Fork test PR: Acceptance blocked until `allowed-for-ci` label applied, `approval_gate` requires environment approval, label stripped on new push

🤖 Generated with [Claude Code](https://claude.com/claude-code)