### PR TITLE
Fix fork CI gate: skip setup_matrix on fork pull_request events (CAT-2665)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,10 @@ on:
   pull_request:
     branches:
       - "main"
-      - "cat-2665-fork-ci-lvm"
   pull_request_target:
     types: [labeled, reopened]
     branches:
       - "main"
-      - "cat-2665-fork-ci-lvm"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     branches:
       - "main"
+      - "cat-2665-fork-ci-lvm"
   pull_request_target:
     types: [labeled, reopened]
     branches:
       - "main"
+      - "cat-2665-fork-ci-lvm"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,6 @@ jobs:
   setup_matrix:
     name: "Setup Test Matrix"
     runs-on: "ubuntu-24.04"
-    # Only run when secrets are guaranteed to be in scope:
-    # - same-repo pull_request (not a fork)
-    # - workflow_dispatch
-    # - pull_request_target from a same-repo branch (rare but valid)
-    # - pull_request_target from a fork that already has the allowed-for-ci label
-    # Fork pull_request events are excluded because GitHub withholds secrets,
-    # causing bundle install to fail against rubygems-puppetcore.puppet.com.
     if: >-
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true) ||
       github.event_name == 'workflow_dispatch' ||
@@ -73,9 +66,6 @@ jobs:
     name: "Fork PR approval gate"
     needs: setup_matrix
     runs-on: ubuntu-latest
-    # Funnels the puppetcore-fork environment approval through a single non-matrix job.
-    # Same-repo PRs and workflow_dispatch skip this; Acceptance handles the skipped case
-    # via always() below.
     if: >-
       github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.fork == true
@@ -94,8 +84,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.setup_matrix.outputs.matrix)}}
-    # always() is required so this is evaluated when approval_gate is skipped
-    # (non-fork events); without it, dependency-skip would cascade.
     if: >-
       always() &&
       needs.setup_matrix.result == 'success' &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,19 @@ jobs:
   setup_matrix:
     name: "Setup Test Matrix"
     runs-on: "ubuntu-24.04"
-    # For pull_request_target (fork PRs), only run once the allowed-for-ci label is present.
+    # Only run when secrets are guaranteed to be in scope:
+    # - same-repo pull_request (not a fork)
+    # - workflow_dispatch
+    # - pull_request_target from a same-repo branch (rare but valid)
+    # - pull_request_target from a fork that already has the allowed-for-ci label
+    # Fork pull_request events are excluded because GitHub withholds secrets,
+    # causing bundle install to fail against rubygems-puppetcore.puppet.com.
     if: >-
-      github.event_name != 'pull_request_target' ||
-      github.event.pull_request.head.repo.fork != true ||
-      contains(github.event.pull_request.labels.*.name, 'allowed-for-ci')
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true) ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request_target' &&
+       (github.event.pull_request.head.repo.fork != true ||
+        contains(github.event.pull_request.labels.*.name, 'allowed-for-ci')))
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
 


### PR DESCRIPTION
## Summary

- `setup_matrix` was running on `pull_request` events from forks, where GitHub withholds secrets. This caused `bundle install` to fail with an empty credential against `rubygems-puppetcore.puppet.com`.
- Delegating modules (powershell, haproxy) avoid this via an outer gate on the `Acceptance` reusable-workflow call; LVM's inline workflow needs the equivalent gate on `setup_matrix` directly.
- The new condition only runs `setup_matrix` when secrets are guaranteed in scope: same-repo `pull_request`, `workflow_dispatch`, or `pull_request_target` (with `allowed-for-ci` label for forks).

## Test plan

- [x] Spec passes on this PR (same-repo `pull_request`)
- [x] Fork test PR #386 — `setup_matrix` skips on initial open, only runs after `allowed-for-ci` label + `puppetcore-fork` approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)