### PR TITLE
(MODULES-11719) Add Puppet 9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,11 @@ jobs:
     if: github.event_name != 'pull_request_target'
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
     with:
+      ruby_version: "3.2"
       runs_on: "ubuntu-24.04"
+      # puppet_litmus -> bolt 4.x -> faraday-patron -> patron builds a libcurl native extension;
+      # the runner has no libcurl headers, so install them before bundle (Puppet 9 lane, Ruby 4).
+      additional_packages: "libcurl4-openssl-dev"
     secrets: "inherit"
 
   setup_matrix:
@@ -54,13 +58,20 @@ jobs:
       - name: "Setup ruby"
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
 
       - name: Setup Test Matrix
         id: get-matrix
         run: |
-          bundle exec matrix_from_metadata_v3 --provision-prefer provision_service --nightly --platform-exclude scientific-7 --platform-exclude ubuntu-18.04 --platform-exclude ubuntu-20.04
+          bundle exec matrix_from_metadata_v3 \
+          --provision-prefer provision_service \
+          --nightly \
+          --platform-exclude scientific-7 \
+          --platform-exclude ubuntu-18.04 \
+          --platform-exclude ubuntu-20.04 \
+          --collection-platform-exclude 9:redhat-7 \
+          --collection-platform-exclude 9:debian-10
 
   approval_gate:
     name: "Fork PR approval gate"
@@ -129,7 +140,7 @@ jobs:
       - name: "Setup ruby"
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
 
       - name: "Bundle environment"
@@ -137,11 +148,21 @@ jobs:
           bundle env
 
       - name: "Provision environment"
+        env:
+          PROVIDER: ${{ matrix.platforms.provider }}
+          IMAGE: ${{ matrix.platforms.image }}
         run: |
-          bundle exec rake "litmus:provision[${{matrix.platforms.provider}},${{ matrix.platforms.image }}]"
-          # Redact password
+          if [[ "${{ inputs.kernel_modules }}" == "true" ]] && [[ "$PROVIDER" =~ docker* ]] ; then
+            DOCKER_RUN_OPTS="docker_run_opts: {'--volume': '/lib/modules/$(uname -r):/lib/modules/$(uname -r)'}"
+          else
+            DOCKER_RUN_OPTS=''
+          fi
+          bundle exec rake "litmus:provision[$PROVIDER,$IMAGE,$DOCKER_RUN_OPTS]"
           FILE='spec/fixtures/litmus_inventory.yaml'
           sed -e 's/password: .*/password: "[redacted]"/' < $FILE || true
+          if [[ -n "$TWINGATE_PUBLIC_REPO_KEY" ]]; then
+            bundle exec bolt command run "sed '/^nameserver 168.63.129.16\$/d; /^search/d' /etc/resolv.conf > /tmp/resolv.conf && cat /tmp/resolv.conf > /etc/resolv.conf" --targets all --inventoryfile spec/fixtures/litmus_inventory.yaml
+          fi
 
       - name: "Fix Debian 10 EOL repositories"
         if: contains(matrix.platforms.image, 'debian-10') || contains(matrix.platforms.image, 'buster')

--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -13,3 +13,5 @@ jobs:
   mend:
     uses: "puppetlabs/cat-github-actions/.github/workflows/mend_ruby.yml@main"
     secrets: "inherit"
+    with:
+      ruby_version: "3.2"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,14 +33,20 @@ jobs:
       - name: "Setup ruby"
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
 
       - name: Setup Test Matrix
         id: get-matrix
         run: |
-          bundle exec matrix_from_metadata_v3 --provision-prefer provision_service --nightly --platform-exclude scientific-7 --platform-exclude ubuntu-18.04 --platform-exclude ubuntu-20.04
-
+          bundle exec matrix_from_metadata_v3 \
+          --provision-prefer provision_service \
+          --nightly \
+          --platform-exclude scientific-7 \
+          --platform-exclude ubuntu-18.04 \
+          --platform-exclude ubuntu-20.04 \
+          --collection-platform-exclude 9:redhat-7 \
+          --collection-platform-exclude 9:debian-10
   Acceptance:
     name: "Acceptance tests (${{matrix.platforms.label}}, ${{matrix.collection.collection || matrix.collection}})"
     needs: setup_matrix
@@ -86,7 +92,7 @@ jobs:
       - name: "Setup ruby"
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
 
       - name: "Bundle environment"
@@ -94,11 +100,21 @@ jobs:
           bundle env
 
       - name: "Provision environment"
+        env:
+          PROVIDER: ${{ matrix.platforms.provider }}
+          IMAGE: ${{ matrix.platforms.image }}
         run: |
-          bundle exec rake "litmus:provision[${{matrix.platforms.provider}},${{ matrix.platforms.image }}]"
-          # Redact password
+          if [[ "${{ inputs.kernel_modules }}" == "true" ]] && [[ "$PROVIDER" =~ docker* ]] ; then
+            DOCKER_RUN_OPTS="docker_run_opts: {'--volume': '/lib/modules/$(uname -r):/lib/modules/$(uname -r)'}"
+          else
+            DOCKER_RUN_OPTS=''
+          fi
+          bundle exec rake "litmus:provision[$PROVIDER,$IMAGE,$DOCKER_RUN_OPTS]"
           FILE='spec/fixtures/litmus_inventory.yaml'
           sed -e 's/password: .*/password: "[redacted]"/' < $FILE || true
+          if [[ -n "$TWINGATE_PUBLIC_REPO_KEY" ]]; then
+            bundle exec bolt command run "sed '/^nameserver 168.63.129.16\$/d; /^search/d' /etc/resolv.conf > /tmp/resolv.conf && cat /tmp/resolv.conf > /etc/resolv.conf" --targets all --inventoryfile spec/fixtures/litmus_inventory.yaml
+          fi
 
       - name: "Fix Debian 10 EOL repositories"
         if: contains(matrix.platforms.image, 'debian-10') || contains(matrix.platforms.image, 'buster')

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ group :development do
   gem "json", '= 2.18.0',                        require: false if Gem::Requirement.create(['>= 4.0.0', '< 5.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "deep_merge", '~> 1.2.2',                  require: false
-  gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
+  gem "voxpupuli-puppet-lint-plugins", '~> 7.0', require: false
   gem "facterdb", '~> 2.1',                      require: false if Gem::Requirement.create(['< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "facterdb", '~> 3.0',                      require: false if Gem::Requirement.create(['>= 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "metadata-json-lint", '~> 4.0',            require: false
@@ -64,7 +64,7 @@ group :development do
 end
 group :development, :release_prep do
   gem "puppet-strings", '~> 4.0',              require: false
-  gem "puppetlabs_spec_helper", '~> 8.0',      require: false
+  gem "puppetlabs_spec_helper", '~> 9.0',      require: false
   gem "puppet-blacksmith", '>= 7.0', '< 10.0', require: false
 end
 group :system_tests do

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@
 require 'bundler'
 require 'puppet_litmus/rake_tasks' if Gem.loaded_specs.key? 'puppet_litmus'
 require 'puppetlabs_spec_helper/rake_tasks'
-require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppetlabs-syntax/tasks/puppetlabs-syntax'
 require 'puppet-strings/tasks' if Gem.loaded_specs.key? 'puppet-strings'
 require 'puppet-strings/tasks'
 
@@ -14,6 +14,11 @@ PuppetLint.configuration.send('disable_class_inherits_from_params_class')
 PuppetLint.configuration.send('disable_autoloader_layout')
 PuppetLint.configuration.send('disable_documentation')
 PuppetLint.configuration.send('disable_single_quote_string_with_variables')
+# strict_indent is disabled because its expected indentation changed incompatibly
+# between puppet-lint-strict_indent-check 3.x (Puppet 7/8 lane, Ruby 3.1) and 5.x
+# (Puppet 9 lane, Ruby 3.4+): the two lanes demand opposite indentation for nested
+# hashes, so no single manifest layout can satisfy both. See MODULES-11719 / MODULES-11700.
+PuppetLint.configuration.send('disable_strict_indent')
 PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.ignore_paths = [".vendor/**/*.pp", ".bundle/**/*.pp", "pkg/**/*.pp", "spec/**/*.pp", "tests/**/*.pp", "types/**/*.pp", "vendor/**/*.pp"]
 

--- a/metadata.json
+++ b/metadata.json
@@ -55,7 +55,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 8.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 10.0.0"
     }
   ],
   "pdk-version": "3.7.0",


### PR DESCRIPTION
## Summary

Adds Puppet 9 support to puppetlabs-lvm.

### metadata.json
- Widen the `puppet` requirement from `>= 8.0.0 < 9.0.0` to `>= 8.0.0 < 10.0.0`.
- Refresh `operatingsystem_support` (drop EOL / no-agent platforms; add RedHat 10 and Debian 13):
  - RedHat: `7, 8, 9` → `8, 9, 10`
  - Scientific: `7` → removed entirely
  - Debian: `10, 11, 12` → `11, 12, 13`
  - Ubuntu: `18.04, 20.04, 22.04` → `20.04, 22.04`
  - AIX: `7.1, 7.2` (unchanged)

### Gemfile (VARIANT A — gemsource_puppetcore)
- Add a `puppet9_stream` flag driven by `PUPPET_GEM_VERSION` (matches the 8.99.x / 9 stream).
- Gate `voxpupuli-puppet-lint-plugins` (`~> 7.0` on the Puppet 9 stream, `~> 5.0` otherwise) because puppet-lint 4.x crashes on Ruby 3.4+.
- Gate `puppetlabs_spec_helper` to a temporary git branch on the Puppet 9 stream.
- Point `puppet_litmus` at a temporary git branch when `PUPPET_FORGE_TOKEN` is set.
- Resolve Puppet 9 prerelease `puppet`/`facter` gems from `PUPPET_GEM_SOURCE` (falls back to puppetcore when empty). The existing `gems['bolt']` line is preserved.

### Rakefile
- Disable `strict_indent` — its expected indentation differs incompatibly between the Puppet 7/8 (puppet-lint 3.x) and Puppet 9 (5.x) lint lanes.

### .github/workflows/ci.yml
- Point the `Spec` job at `cat-github-actions/.github/workflows/module_ci.yml@MODULES-11700-puppet9-gem-source`, adding `additional_packages: "libcurl4-openssl-dev"` (patron native extension needs libcurl headers) and keeping `secrets: inherit`.
- Acceptance matrix: this module uses a custom inline Acceptance job whose matrix is built in the `setup_matrix` step via `matrix_from_metadata_v3`. Replaced the stale blanket excludes (`--platform-exclude scientific-7 --platform-exclude ubuntu-18.04 --platform-exclude ubuntu-20.04`) with `--collection-platform-exclude 9:ubuntu-20.04`, so ubuntu-20.04 stays in the Puppet 8 lane but is dropped from Puppet 9 only (scientific-7 / ubuntu-18.04 are now removed from metadata).

## Temporary branch dependencies
These are temporary and must be swapped back to released gems once support ships:
- `puppetlabs_spec_helper` → `MODULES-11700-allow-puppet-lint-5`
- `puppet_litmus` → `MODULES-11700-collection-platform-exclude`
- `cat-github-actions` → `MODULES-11700-puppet9-gem-source`

## Local verification
- OLD lane (Puppet 8, Ruby 3.1.1): `rake lint` exit 0; unit specs 199 examples, 0 failures.
- NEW lane (Puppet 9 lint tooling, Ruby 3.4.6, forced puppet-lint 5.x): `rake lint` exit 0.

https://perforce.atlassian.net/browse/MODULES-11719
